### PR TITLE
FIX - allow for passworded pdfs on ios

### DIFF
--- a/ios/RNTPTDocumentView.h
+++ b/ios/RNTPTDocumentView.h
@@ -28,6 +28,7 @@
 @property (nonatomic, assign) BOOL pageIndicatorShowsWithControls;
 
 @property NSString *document;
+@property NSString *password;
 @property BOOL showNavButton;
 @property NSString *navButtonPath;
 @property (nonatomic, strong) NSDictionary<NSString *, NSString *> *customHeaders;

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -68,7 +68,7 @@
         fileURL = [NSURL fileURLWithPath:_document];
     }
     
-    [_documentViewController openDocumentWithURL:fileURL password:self.password];
+    [_documentViewController openDocumentWithURL:fileURL password:_password];
 }
 
 -(void)disableElements:(NSArray<NSString*>*)disabledElements

--- a/ios/RNTPTDocumentViewManager.m
+++ b/ios/RNTPTDocumentViewManager.m
@@ -22,10 +22,11 @@ RCT_CUSTOM_VIEW_PROPERTY(document, NSString, RNTPTDocumentView)
 
 RCT_CUSTOM_VIEW_PROPERTY(password, NSString, RNTPTDocumentView)
 {
-    if (json) {
+    if (json && [RCTConvert NSString:json]) {
         view.password = [RCTConvert NSString:json];
     }
 }
+
 
 RCT_CUSTOM_VIEW_PROPERTY(showLeadingNavButton, BOOL, RNTPTDocumentView)
 {


### PR DESCRIPTION
Password protected pdfs still aren't working on ios, so I changed the way that the password field is obtained and I believe that now passwords are working properly.