### PR TITLE
Add missing import to fix build error (on iOS)

### DIFF
--- a/ios/RNTPTDocumentViewManager.h
+++ b/ios/RNTPTDocumentViewManager.h
@@ -8,6 +8,7 @@
 #import "RNTPTDocumentView.h"
 
 #import <React/RCTViewManager.h>
+#import <React/RCTUIManager.h>
 
 @interface RNTPTDocumentViewManager : RCTViewManager <RNTPTDocumentViewDelegate>
 


### PR DESCRIPTION
This line:

https://github.com/PDFTron/pdftron-react-native/blob/master/ios/RNTPTDocumentViewManager.m#L150

blows up when trying to build on iOS. `RCTUIManager.h` contains the category definition for the property `uiManager`

https://github.com/facebook/react-native/blob/8831cc6ac23775ad568e776aa20a2b5b25abbc2a/React/Modules/RCTUIManager.m#L1597-L1602

