### PR TITLE
Fix: Attempt to invoke method on null object

### DIFF
--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -322,16 +322,16 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView {
 
     @Override
     protected void onDetachedFromWindow() {
-        super.onDetachedFromWindow();
-
-        getViewTreeObserver().removeOnGlobalLayoutListener(mOnGlobalLayoutListener);
-
         if (getPdfViewCtrl() != null) {
             getPdfViewCtrl().removePageChangeListener(mPageChangeListener);
         }
         if (getToolManager() != null) {
             getToolManager().removeAnnotationModificationListener(mAnnotationModificationListener);
         }
+        
+        super.onDetachedFromWindow();
+
+        getViewTreeObserver().removeOnGlobalLayoutListener(mOnGlobalLayoutListener);
     }
 
     @Override


### PR DESCRIPTION
Was having some issues with the latest version.
When leaving the PDFTron screen our app was crashing with this error:

```	
20:32:52.393	unknown:ReactNative	Exception in native call
java.lang.NullPointerException: Attempt to invoke virtual method 'com.pdftron.pdf.controls.PdfViewCtrlTabFragment com.pdftron.pdf.controls.PdfViewCtrlTabHostFragment.getCurrentPdfViewCtrlFragment()' on a null object reference
	at com.pdftron.reactnative.views.DocumentView.getPdfViewCtrl(DocumentView.java:539)
	at com.pdftron.reactnative.views.DocumentView.onDetachedFromWindow(DocumentView.java:329)
	at android.view.View.dispatchDetachedFromWindow(View.java:14561)
	at android.view.ViewGroup.dispatchDetachedFromWindow(ViewGroup.java:3071)
	at android.view.ViewGroup.dispatchDetachedFromWindow(ViewGroup.java:3063)
	at android.view.ViewGroup.dispatchDetachedFromWindow(ViewGroup.java:3063)
	at android.view.ViewGroup.removeViewInternal(ViewGroup.java:4603)
	at android.view.ViewGroup.removeViewAt(ViewGroup.java:4552)
	at com.facebook.react.views.view.ReactViewGroup.removeViewAt(ReactViewGroup.java:469)
	at com.facebook.react.views.view.ReactViewManager.removeViewAt(ReactViewManager.java:389)
	at com.facebook.react.views.view.ReactViewManager.removeViewAt(ReactViewManager.java:37)
	at com.facebook.react.uimanager.NativeViewHierarchyManager.manageChildren(NativeViewHierarchyManager.java:457)
	at com.facebook.react.uimanager.UIViewOperationQueue$ManageChildrenOperation.execute(UIViewOperationQueue.java:205)
	at com.facebook.react.uimanager.UIViewOperationQueue$1.run(UIViewOperationQueue.java:779)
	at com.facebook.react.uimanager.UIViewOperationQueue.flushPendingBatches(UIViewOperationQueue.java:888)
	at com.facebook.react.uimanager.UIViewOperationQueue.access$2200(UIViewOperationQueue.java:42)
	at com.facebook.react.uimanager.UIViewOperationQueue$DispatchUIFrameCallback.doFrameGuarded(UIViewOperationQueue.java:948)
	at com.facebook.react.uimanager.GuardedFrameCallback.doFrame(GuardedFrameCallback.java:28)
	at com.facebook.react.modules.core.ReactChoreographer$ReactChoreographerDispatcher.doFrame(ReactChoreographer.java:174)
	at com.facebook.react.modules.core.ChoreographerCompat$FrameCallback$1.doFrame(ChoreographerCompat.java:84)
	at android.view.Choreographer$CallbackRecord.run(Choreographer.java:856)
	at android.view.Choreographer.doCallbacks(Choreographer.java:670)
	at android.view.Choreographer.doFrame(Choreographer.java:603)
	at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:844)
	at android.os.Handler.handleCallback(Handler.java:739)
	at android.os.Handler.dispatchMessage(Handler.java:95)
	at android.os.Looper.loop(Looper.java:148)
	at android.app.ActivityThread.main(ActivityThread.java:5417)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:726)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:616)
```

Had to change the order which the methods were called. Because the fragment was removed already. 