### PR TITLE
Fix for iOS FitMode

### DIFF
--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -778,12 +778,15 @@
 {
     if ([fitMode isEqualToString:@"FitPage"]) {
         [self.documentViewController.pdfViewCtrl SetPageViewMode:e_trn_fit_page];
+        [self.documentViewController.pdfViewCtrl SetPageRefViewMode:e_trn_fit_page];
     }
     else if ([fitMode isEqualToString:@"FitWidth"]) {
         [self.documentViewController.pdfViewCtrl SetPageViewMode:e_trn_fit_width];
+        [self.documentViewController.pdfViewCtrl SetPageRefViewMode:e_trn_fit_width];
     }
     else if ([fitMode isEqualToString:@"FitHeight"]) {
         [self.documentViewController.pdfViewCtrl SetPageViewMode:e_trn_fit_height];
+        [self.documentViewController.pdfViewCtrl SetPageRefViewMode:e_trn_fit_height];
     }
     else if ([fitMode isEqualToString:@"Zoom"]) {
         [self.documentViewController.pdfViewCtrl SetPageViewMode:e_trn_zoom];


### PR DESCRIPTION
The "fitMode" property was not updating the view on iOS so I had to set de "SetPageRefViewMode" as well in the native code.
This way the view opened as I had set in the "fitMode" property.
I don't know if it's the best implementations, fell free to do any changes on the code.

Tested on iPhones: 6, 6 Plus, 5c and iPad mini.