### PR TITLE
Add support for Pan tool to setToolMode

### DIFF
--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -336,6 +336,8 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView {
             mode = ToolManager.ToolMode.AREA_MEASURE_CREATE;
         } else if ("TextSelect".equals(item)) {
             mode = ToolManager.ToolMode.TEXT_SELECT;
+        } else if ("Pan".equals(item)) {
+            mode = ToolManager.ToolMode.PAN;
         } else if ("AnnotationEdit".equals(item)) {
             mode = ToolManager.ToolMode.ANNOT_EDIT_RECT_GROUP;
         }

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -512,6 +512,10 @@
     {
         toolClass = [PTTextSelectTool class];
     }
+    else if ( [toolMode isEqualToString:@"Pan"] )
+    {
+        toolClass = [PTPanTool class];
+    }
     else if ( [toolMode isEqualToString:@"AnnotationCreateTextHighlight"])
     {
         toolClass = [PTTextHighlightCreate class];

--- a/src/Config/Config.js
+++ b/src/Config/Config.js
@@ -37,6 +37,7 @@ export default {
   Tools: {
     annotationEdit : 'AnnotationEdit',
     textSelect : 'TextSelect',
+    pan: 'Pan',
     annotationCreateSticky : 'AnnotationCreateSticky',
     annotationCreateFreeHand : 'AnnotationCreateFreeHand',
     annotationCreateTextHighlight : 'AnnotationCreateTextHighlight',


### PR DESCRIPTION
Add a constant for the pan tool and handling for both Android and iOS.

For some reason the pan tool is not included in the current set of supported tools. This change simply adds the pan tool.