### PR TITLE
Add useStylusAsPen prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,6 +349,7 @@ A component for displaying documents of different types such as PDF, docx, pptx,
 - [overrideAnnotationMenuBehavior](#overrideannotationmenubehavior)
 - [onAnnotationMenuPress](#onannotationmenupress)
 - [pageChangeOnTap](#pagechangeontap)
+- [useStylusAsPen](#usestylusaspen)
 
 ##### document
 string, required
@@ -475,6 +476,9 @@ Action | Param
 
 ##### pageChangeOnTap
 bool, optional, default to true
+##### useStylusAsPen
+bool, optional, default to false
+If true, stylus will act as a pen in pan mode, otherwise it will act as finger
 ##### followSystemDarkMode
 bool, optional, Android only, default to true
 If true, UI will appear in dark color when System is dark mode. Otherwise it will use viewer setting instead.

--- a/android/src/main/java/com/pdftron/reactnative/viewmanagers/DocumentViewViewManager.java
+++ b/android/src/main/java/com/pdftron/reactnative/viewmanagers/DocumentViewViewManager.java
@@ -157,6 +157,11 @@ public class DocumentViewViewManager extends ViewGroupManager<DocumentView> {
         documentView.setAutoSaveEnabled(autoSaveEnabled);
     }
 
+    @ReactProp(name = "useStylusAsPen")
+    public void setUseStylusAsPen(DocumentView documentView, boolean useStylusAsPen) {
+        documentView.setUseStylusAsPen(useStylusAsPen);
+    }
+
     @ReactProp(name = "collabEnabled")
     public void setCollabEnabled(DocumentView documentView, boolean collabEnabled) {
         documentView.setCollabEnabled(collabEnabled);

--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -1182,7 +1182,7 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView {
         getToolManager().addAnnotationModificationListener(mAnnotationModificationListener);
         getToolManager().addAnnotationsSelectionListener(mAnnotationsSelectionListener);
 
-        getToolManager().setUseStylusAsPen(mUseStylusAsPen);
+        getToolManager().setStylusAsPen(mUseStylusAsPen);
 
         getPdfViewCtrlTabFragment().addQuickMenuListener(mQuickMenuListener);
 

--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -145,6 +145,8 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView {
 
     private boolean mAutoSaveEnabled = true;
 
+    private boolean mUseStylusAsPen = false;
+
     // collab
     private CollabManager mCollabManager;
     private boolean mCollabEnabled;
@@ -356,6 +358,10 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView {
 
     public void setAutoSaveEnabled(boolean autoSaveEnabled) {
         mAutoSaveEnabled = autoSaveEnabled;
+    }
+
+    public void setUseStylusAsPen(boolean useStylusAsPen) {
+        mUseStylusAsPen = useStylusAsPen;
     }
 
     public void setCollabEnabled(boolean collabEnabled) {
@@ -1175,6 +1181,8 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView {
 
         getToolManager().addAnnotationModificationListener(mAnnotationModificationListener);
         getToolManager().addAnnotationsSelectionListener(mAnnotationsSelectionListener);
+
+        getToolManager().setUseStylusAsPen(mUseStylusAsPen);
 
         getPdfViewCtrlTabFragment().addQuickMenuListener(mQuickMenuListener);
 

--- a/ios/RNTPTDocumentView.h
+++ b/ios/RNTPTDocumentView.h
@@ -78,6 +78,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic) BOOL continuousAnnotationEditing;
 
+@property (nonatomic) BOOL useStylusAsPen;
+
 @property (nonatomic) BOOL showSavedSignatures;
 
 @property (nonatomic, assign, getter=isCollabEnabled) BOOL collabEnabled;

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -56,6 +56,8 @@ NS_ASSUME_NONNULL_END
     _pageChangeOnTap = NO;
     _thumbnailViewEditingEnabled = YES;
     _selectAnnotationAfterCreation = YES;
+
+    _useStylusAsPen = YES;
 }
 
 -(instancetype)initWithFrame:(CGRect)frame
@@ -1112,6 +1114,13 @@ NS_ASSUME_NONNULL_END
     // Shows saved signatures.
     self.toolManager.showDefaultSignature = self.showSavedSignatures;
     
+    // Use Apple Pencil as a pen
+    Class pencilTool = [PTFreeHandCreate class];
+    if (@available(iOS 13.0, *)) {
+        pencilTool = [PTPencilDrawingCreate class];
+    }
+    self.toolManager.pencilTool = self.useStylusAsPen ? pencilTool : [PTPanTool class];
+
     // Disable UI elements.
     [self disableElementsInternal:self.disabledElements];
     
@@ -1231,6 +1240,15 @@ NS_ASSUME_NONNULL_END
 {
     _showSavedSignatures = showSavedSignatures;
     
+    [self applyViewerSettings];
+}
+
+#pragma mark - Stylus
+
+- (void)setUseStylusAsPen:(BOOL)useStylusAsPen
+{
+    _useStylusAsPen = useStylusAsPen;
+
     [self applyViewerSettings];
 }
 

--- a/ios/RNTPTDocumentViewManager.m
+++ b/ios/RNTPTDocumentViewManager.m
@@ -185,6 +185,13 @@ RCT_CUSTOM_VIEW_PROPERTY(showSavedSignatures, BOOL, RNTPTDocumentView)
     }
 }
 
+RCT_CUSTOM_VIEW_PROPERTY(useStylusAsPen, BOOL, RNTPTDocumentView)
+{
+    if (json) {
+        view.useStylusAsPen = [RCTConvert BOOL:json];
+    }
+}
+
 RCT_CUSTOM_VIEW_PROPERTY(collabEnabled, BOOL, RNTPTDocumentView)
 {
     if (json) {

--- a/src/DocumentView/DocumentView.js
+++ b/src/DocumentView/DocumentView.js
@@ -57,6 +57,7 @@ export default class DocumentView extends PureComponent {
     autoSaveEnabled: PropTypes.bool,
     pageChangeOnTap: PropTypes.bool,
     followSystemDarkMode: PropTypes.bool,
+    useStylusAsPen:PropTypes.bool,
     ...ViewPropTypes,
   };
 

--- a/src/DocumentView/DocumentView.js
+++ b/src/DocumentView/DocumentView.js
@@ -57,7 +57,7 @@ export default class DocumentView extends PureComponent {
     autoSaveEnabled: PropTypes.bool,
     pageChangeOnTap: PropTypes.bool,
     followSystemDarkMode: PropTypes.bool,
-    useStylusAsPen:PropTypes.bool,
+    useStylusAsPen: PropTypes.bool,
     ...ViewPropTypes,
   };
 


### PR DESCRIPTION
Allows setting whether or not a stylus (e.g. Apple Pencil on iOS) starts drawing ink annotations when in Pan mode.
Default is false on Android, true on iOS.