### PR TITLE
Long press menu enabled prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,7 @@ A component for displaying documents of different types such as PDF, docx, pptx,
 - [onAnnotationMenuPress](#onannotationmenupress)
 - [pageChangeOnTap](#pagechangeontap)
 - [useStylusAsPen](#usestylusaspen)
+- [longPressMenuEnabled](#longPressMenuEnabled)
 
 ##### document
 string, required
@@ -442,6 +443,11 @@ Name | Type | Description
 --- | --- | ---
 annotationMenu | string | One of `Config.AnnotationMenu` string constants
 annotations | array | An array of `{id, rect}` objects, where `id` is the annotation identifier and `rect={x1, y1, x2, y2}` specifies the annotation's screen rect.
+
+##### longPressMenuEnabled
+bool, optional, default to true
+
+If true, the viewer will show the default menu on long press.
 
 ##### longPressMenuItems
 array of `Config.LongPressMenu` string constants, optional

--- a/android/src/main/java/com/pdftron/reactnative/viewmanagers/DocumentViewViewManager.java
+++ b/android/src/main/java/com/pdftron/reactnative/viewmanagers/DocumentViewViewManager.java
@@ -1,6 +1,5 @@
 package com.pdftron.reactnative.viewmanagers;
 
-import android.app.Activity;
 import android.content.Intent;
 import android.util.Log;
 import android.util.SparseArray;
@@ -186,7 +185,12 @@ public class DocumentViewViewManager extends ViewGroupManager<DocumentView> {
     public void setLongPressMenuItems(DocumentView documentView, @NonNull ReadableArray items) {
         documentView.setLongPressMenuItems(items);
     }
-    
+
+    @ReactProp(name = "longPressMenuEnabled")
+    public void setLongPressMenuEnabled(DocumentView documentView, boolean longPressMenuEnabled) {
+        documentView.setLongPressMenuEnabled(longPressMenuEnabled);
+    }
+
     @ReactProp(name = "hideAnnotationMenu")
     public void setHideAnnotationMenu(DocumentView documentView, @NonNull ReadableArray tools) {
         documentView.setHideAnnotationMenu(tools);

--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -389,6 +389,10 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView {
         mLongPressMenuItems = items != null ? items.toArrayList() : null;
     }
 
+    public void setLongPressMenuEnabled(boolean longPressMenuEnabled) {
+        mToolManagerBuilder = mToolManagerBuilder.setDisableQuickMenu(!longPressMenuEnabled);
+    }
+
     public void setPageChangeOnTap(boolean pageChangeOnTap) {
         Context context = getContext();
         if (context != null) {

--- a/ios/RNTPTDocumentView.h
+++ b/ios/RNTPTDocumentView.h
@@ -96,6 +96,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, weak, nullable) id <RNTPTDocumentViewDelegate> delegate;
 
+@property (nonatomic, assign, getter=isLongPressMenuEnabled) BOOL longPressMenuEnabled;
+
 #pragma mark - Methods
 
 - (void)setToolMode:(NSString *)toolMode;

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -58,6 +58,7 @@ NS_ASSUME_NONNULL_END
     _selectAnnotationAfterCreation = YES;
 
     _useStylusAsPen = YES;
+    _longPressMenuEnabled = YES;
 }
 
 -(instancetype)initWithFrame:(CGRect)frame
@@ -1564,6 +1565,10 @@ NS_ASSUME_NONNULL_END
 
 - (BOOL)rnt_documentViewController:(PTDocumentViewController *)documentViewController filterMenuItemsForLongPressMenu:(UIMenuController *)menuController
 {
+    if (!self.longPressMenuEnabled) {
+        menuController.menuItems = nil;
+        return NO;
+    }
     // Mapping from menu item title to identifier.
     NSDictionary<NSString *, NSString *> *map = @{
         @"Copy": @"copy",

--- a/ios/RNTPTDocumentViewManager.m
+++ b/ios/RNTPTDocumentViewManager.m
@@ -283,6 +283,13 @@ RCT_CUSTOM_VIEW_PROPERTY(overrideLongPressMenuBehavior, NSArray, RNTPTDocumentVi
     }
 }
 
+RCT_CUSTOM_VIEW_PROPERTY(longPressMenuEnabled, BOOL, RNTPTDocumentView)
+{
+    if (json) {
+        view.longPressMenuEnabled = [RCTConvert BOOL:json];
+    }
+}
+
 - (UIView *)view
 {
     RNTPTDocumentView *documentView = [[RNTPTDocumentView alloc] init];


### PR DESCRIPTION
Add `longPressMenuEnabled` BOOL to determine whether or not to show the long press menu.
Default is `true`.