### PR TITLE
iOS Edit Text Fix

### DIFF
--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -1560,6 +1560,8 @@ NS_ASSUME_NONNULL_END
         return NO;
     }
         
+    NSString *editString = ([annot GetType] == e_ptFreeText) ? @"editText" : @"editInk";
+
     // Mapping from menu item title to identifier.
     NSDictionary<NSString *, NSString *> *map = @{
         @"Style": @"style",
@@ -1568,8 +1570,7 @@ NS_ASSUME_NONNULL_END
         @"Delete": @"delete",
         @"Type": @"markupType",
         @"Search": @"search",
-        @"Edit": @"editInk",
-        @"Edit Text": @"editText",
+        @"Edit": editString,
         @"Flatten": @"flatten",
         @"Open": @"openAttachment",
     };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "2.0.1-beta.10",
+  "version": "2.0.1-beta.11",
   "description": "React Native Pdftron",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
iOS `Edit Text` string was recently changed to `Edit`.
Updating the wrapper to match.