### PR TITLE
function rename and iOS fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -753,6 +753,8 @@ this._viewer.setFlagForFields(['First Name', 'Last Name'], Config.FieldFlags.Rea
 ##### setValuesForFields
 Set field values on one or more form fields.
 
+Note: the old function `setValueForFields` is deprecated. Please use this one.
+
 Parameters:
 
 Name | Type | Description
@@ -815,6 +817,8 @@ this._viewer.selectAnnotation('annotId1', 1);
 ##### setFlagsForAnnotations
 To set flags for specified annotations in the current document. The `flagValue` controls whether a flag will be set to or removed from the annotation.
 
+Note: the old function `setFlagForAnnotations` is deprecated. Please use this one.
+
 Parameters:
 
 Name | Type | Description
@@ -842,6 +846,8 @@ this._viewer.setFlagsForAnnotations([
 ```
 ##### setPropertiesForAnnotation
 To set properties for specified annotation in the current document, if it is valid. 
+
+Note: the old function `setPropertyForAnnotation` is deprecated. Please use this one.
 
 Parameters:
 

--- a/README.md
+++ b/README.md
@@ -618,12 +618,12 @@ fields | array | array of field data in the format `{fieldName: string, fieldVal
 - [deleteAnnotations](#deleteannotations)
 - [saveDocument](#savedocument)
 - [setFlagForFields](#setFlagForFields)
-- [setValueForFields](#setValueForFields)
+- [setValuesForFields](#setValuesForFields)
 - [importAnnotationCommand](#importannotationcommand)
 - [handleBackButton](#handlebackbutton)
 - [selectAnnotation](#selectAnnotation)
-- [setFlagForAnnotations](#setFlagForAnnotations)
-- [setPropertyForAnnotation](#setPropertyForAnnotation)
+- [setFlagsForAnnotations](#setFlagsForAnnotations)
+- [setPropertiesForAnnotation](#setPropertiesForAnnotation)
 - [getPageCropBox](#getPageCropBox)
 - [setCurrentPage](#setCurrentPage)
 - [getDocumentPath](#getDocumentPath)
@@ -750,7 +750,7 @@ Returns a Promise.
 this._viewer.setFlagForFields(['First Name', 'Last Name'], Config.FieldFlags.ReadOnly, true);
 ```
 
-##### setValueForFields
+##### setValuesForFields
 Set field values on one or more form fields.
 
 Parameters:
@@ -762,7 +762,7 @@ fieldsMap | object | map of field names and values which should be set
 Returns a Promise.
 
 ```js
-this._viewer.setValueForFields({
+this._viewer.setValuesForFields({
   'textField1': 'Test',
   'textField2': 1234,
   'checkboxField1': true,
@@ -812,8 +812,8 @@ Return a Promise.
 this._viewer.selectAnnotation('annotId1', 1);
 ```
 
-##### setFlagForAnnotations
-To set flag for specified annotations in the current document. The `flagValue` controls whether a flag will be set to or removed from the annotation.
+##### setFlagsForAnnotations
+To set flags for specified annotations in the current document. The `flagValue` controls whether a flag will be set to or removed from the annotation.
 
 Parameters:
 
@@ -825,7 +825,7 @@ Return a Promise.
 
 ```js
 //  Set flag for annotations in the current document.
-this._viewer.setFlagForAnnotations([
+this._viewer.setFlagsForAnnotations([
     {
         id: 'annotId1',
         pageNumber: 1,
@@ -840,7 +840,7 @@ this._viewer.setFlagForAnnotations([
     }
 ]);
 ```
-##### setPropertyForAnnotation
+##### setPropertiesForAnnotation
 To set properties for specified annotation in the current document, if it is valid. 
 
 Parameters:
@@ -865,7 +865,7 @@ Return a promise.
 
 ```js
 // Set properties for annotation in the current document.
-this._viewer.setPropertyForAnnotation('Pdftron', 1, {
+this._viewer.setPropertiesForAnnotation('Pdftron', 1, {
   rect: {
     x1: 1.1,    // left
     y1: 3,      // bottom

--- a/android/src/main/java/com/pdftron/reactnative/modules/DocumentViewModule.java
+++ b/android/src/main/java/com/pdftron/reactnative/modules/DocumentViewModule.java
@@ -180,12 +180,12 @@ public class DocumentViewModule extends ReactContextBaseJavaModule implements Ac
     }
 
     @ReactMethod
-    public void setValueForFields(final int tag, final ReadableMap map, final Promise promise) {
+    public void setValuesForFields(final int tag, final ReadableMap map, final Promise promise) {
         getReactApplicationContext().runOnUiQueueThread(new Runnable() {
             @Override
             public void run() {
                 try {
-                    mDocumentViewInstance.setValueForFields(tag, map);
+                    mDocumentViewInstance.setValuesForFields(tag, map);
                     promise.resolve(null);
                 } catch (Exception ex) {
                     promise.reject(ex);
@@ -225,12 +225,12 @@ public class DocumentViewModule extends ReactContextBaseJavaModule implements Ac
     }
 
     @ReactMethod
-    public void setFlagForAnnotations(final int tag, final ReadableArray annotationFlaglist, final Promise promise) {
+    public void setFlagsForAnnotations(final int tag, final ReadableArray annotationFlaglist, final Promise promise) {
         getReactApplicationContext().runOnUiQueueThread(new Runnable() {
             @Override
             public void run() {
                 try {
-                    mDocumentViewInstance.setFlagForAnnotations(tag, annotationFlaglist);
+                    mDocumentViewInstance.setFlagsForAnnotations(tag, annotationFlaglist);
                     promise.resolve(null);
                 } catch (Exception ex) {
                     promise.reject(ex);
@@ -255,12 +255,12 @@ public class DocumentViewModule extends ReactContextBaseJavaModule implements Ac
     }
 
     @ReactMethod
-    public void setPropertyForAnnotation(final int tag, final String annotId, final int pageNumber, final ReadableMap propertyMap, final Promise promise) {
+    public void setPropertiesForAnnotation(final int tag, final String annotId, final int pageNumber, final ReadableMap propertyMap, final Promise promise) {
         getReactApplicationContext().runOnUiQueueThread(new Runnable() {
             @Override
             public void run() {
                 try {
-                    mDocumentViewInstance.setPropertyForAnnotation(tag, annotId, pageNumber, propertyMap);
+                    mDocumentViewInstance.setPropertiesForAnnotation(tag, annotId, pageNumber, propertyMap);
                     promise.resolve(null);
                 } catch (Exception ex) {
                     promise.reject(ex);

--- a/android/src/main/java/com/pdftron/reactnative/viewmanagers/DocumentViewViewManager.java
+++ b/android/src/main/java/com/pdftron/reactnative/viewmanagers/DocumentViewViewManager.java
@@ -337,12 +337,12 @@ public class DocumentViewViewManager extends ViewGroupManager<DocumentView> {
         }
     }
 
-    public void setValueForFields(int tag, ReadableMap map) throws PDFNetException {
+    public void setValuesForFields(int tag, ReadableMap map) throws PDFNetException {
         DocumentView documentView = mDocumentViews.get(tag);
         if (documentView != null) {
-            documentView.setValueForFields(map);
+            documentView.setValuesForFields(map);
         } else {
-            throw new PDFNetException("", 0L, getName(), "setValueForFields", "Unable to find DocumentView.");
+            throw new PDFNetException("", 0L, getName(), "setValuesForFields", "Unable to find DocumentView.");
         }
     }
 
@@ -364,12 +364,12 @@ public class DocumentViewViewManager extends ViewGroupManager<DocumentView> {
         }
     }
 
-    public void setFlagForAnnotations(int tag, ReadableArray annotationFlagList) throws PDFNetException {
+    public void setFlagsForAnnotations(int tag, ReadableArray annotationFlagList) throws PDFNetException {
         DocumentView documentView = mDocumentViews.get(tag);
         if (documentView != null) {
-            documentView.setFlagForAnnotations(annotationFlagList);
+            documentView.setFlagsForAnnotations(annotationFlagList);
         } else {
-            throw new PDFNetException("", 0L, getName(), "setFlagForAnnotation", "Unable to find DocumentView.");
+            throw new PDFNetException("", 0L, getName(), "setFlagsForAnnotation", "Unable to find DocumentView.");
         }
     }
   
@@ -382,12 +382,12 @@ public class DocumentViewViewManager extends ViewGroupManager<DocumentView> {
         }
     }
 
-    public void setPropertyForAnnotation(int tag, String annotId, int pageNumber, ReadableMap propertyMap) throws PDFNetException {
+    public void setPropertiesForAnnotation(int tag, String annotId, int pageNumber, ReadableMap propertyMap) throws PDFNetException {
         DocumentView documentView = mDocumentViews.get(tag);
         if (documentView != null) {
-            documentView.setPropertyForAnnotation(annotId, pageNumber, propertyMap);
+            documentView.setPropertiesForAnnotation(annotId, pageNumber, propertyMap);
         } else {
-            throw new PDFNetException("", 0L, getName(), "setPropertyForAnnotation", "Unable to find DocumentView.");
+            throw new PDFNetException("", 0L, getName(), "setPropertiesForAnnotation", "Unable to find DocumentView.");
         }
     }
 

--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -1514,7 +1514,7 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView {
         }
     }
 
-    public void setValueForFields(ReadableMap readableMap) throws PDFNetException {
+    public void setValuesForFields(ReadableMap readableMap) throws PDFNetException {
         PDFViewCtrl pdfViewCtrl = getPdfViewCtrl();
         PDFDoc pdfDoc = pdfViewCtrl.getDoc();
 
@@ -1658,7 +1658,7 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView {
         return false;
     }
 
-    public void setPropertyForAnnotation(String annotId, int pageNumber, ReadableMap propertyMap) throws PDFNetException {
+    public void setPropertiesForAnnotation(String annotId, int pageNumber, ReadableMap propertyMap) throws PDFNetException {
         PDFViewCtrl pdfViewCtrl = getPdfViewCtrl();
         ToolManager toolManager = getToolManager();
 
@@ -1738,7 +1738,7 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView {
         }
     }
 
-    public void setFlagForAnnotations(ReadableArray annotationFlagList) throws PDFNetException {
+    public void setFlagsForAnnotations(ReadableArray annotationFlagList) throws PDFNetException {
         PDFViewCtrl pdfViewCtrl = getPdfViewCtrl();
         ToolManager toolManager = getToolManager();
         int flagCount = annotationFlagList.size();

--- a/ios/RNTPTDocumentView.h
+++ b/ios/RNTPTDocumentView.h
@@ -289,4 +289,8 @@ static NSString * const PTFormFieldValueKey = @"fieldValue";
 
 @end
 
+
+@interface RNTPTThumbnailsViewController : PTThumbnailsViewController
+
+@end
 NS_ASSUME_NONNULL_END

--- a/ios/RNTPTDocumentView.h
+++ b/ios/RNTPTDocumentView.h
@@ -273,13 +273,13 @@ static NSString * const PTFormFieldValueKey = @"fieldValue";
 
 - (void)setFlagForFields:(NSArray<NSString *> *)fields setFlag:(PTFieldFlag)flag toValue:(BOOL)value;
 
-- (void)setValueForFields:(NSDictionary<NSString *, id> *)map;
+- (void)setValuesForFields:(NSDictionary<NSString *, id> *)map;
 
-- (void)setFlagForAnnotations:(NSArray *)annotationFlagList;
+- (void)setFlagsForAnnotations:(NSArray *)annotationFlagList;
 
 - (void)selectAnnotation:(NSString *)annotationId pageNumber:(NSInteger)pageNumber;
 
-- (void)setPropertyForAnnotation:(NSString *)annotationId pageNumber:(NSInteger)pageNumber propertyMap:(NSDictionary *)propertyMap;
+- (void)setPropertiesForAnnotation:(NSString *)annotationId pageNumber:(NSInteger)pageNumber propertyMap:(NSDictionary *)propertyMap;
 
 - (NSDictionary<NSString *, NSNumber *> *)getPageCropBox:(NSInteger)pageNumber;
 

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -881,7 +881,7 @@ NS_ASSUME_NONNULL_END
 
 #pragma mark - Annotation Flag
 
-- (void)setFlagForAnnotations:(NSArray *)annotationFlagList
+- (void)setFlagsForAnnotations:(NSArray *)annotationFlagList
 {
     if (annotationFlagList.count == 0) {
         return;
@@ -983,7 +983,7 @@ NS_ASSUME_NONNULL_END
     }
 }
 
-- (void)setValueForFields:(NSDictionary<NSString *, id> *)map
+- (void)setValuesForFields:(NSDictionary<NSString *, id> *)map
 {
     PTPDFViewCtrl *pdfViewCtrl = self.pdfViewCtrl;
     BOOL shouldUnlock = NO;
@@ -2089,7 +2089,7 @@ NS_ASSUME_NONNULL_END
 
 #pragma mark - Set Property for Annotation
 
-- (void)setPropertyForAnnotation:(NSString *)annotationId pageNumber:(NSInteger)pageNumber propertyMap:(NSDictionary *)propertyMap {
+- (void)setPropertiesForAnnotation:(NSString *)annotationId pageNumber:(NSInteger)pageNumber propertyMap:(NSDictionary *)propertyMap {
     
     NSError *error;
     

--- a/ios/RNTPTDocumentViewManager.h
+++ b/ios/RNTPTDocumentViewManager.h
@@ -32,13 +32,13 @@
 
 - (void)setFlagForFieldsForDocumentViewTag:(NSNumber *)tag forFields:(NSArray<NSString *> *)fields setFlag:(PTFieldFlag)flag toValue:(BOOL)value;
 
-- (void)setValueForFieldsForDocumentViewTag:(NSNumber *)tag map:(NSDictionary<NSString *, id> *)map;
+- (void)setValuesForFieldsForDocumentViewTag:(NSNumber *)tag map:(NSDictionary<NSString *, id> *)map;
 
-- (void)setFlagForAnnotationsForDocumentViewTag:(NSNumber*) tag annotationFlagList:(NSArray *)annotationFlagList;
+- (void)setFlagsForAnnotationsForDocumentViewTag:(NSNumber*) tag annotationFlagList:(NSArray *)annotationFlagList;
 
 - (void)selectAnnotationForDocumentViewTag:(NSNumber *)tag annotationId:(NSString *)annotationId pageNumber:(NSInteger)pageNumber;
 
-- (void)setPropertyForAnnotation:(NSNumber *)tag annotationId:(NSString *)annotationId pageNumber:(NSInteger)pageNumber propertyMap:(NSDictionary *)propertyMap;
+- (void)setPropertiesForAnnotation:(NSNumber *)tag annotationId:(NSString *)annotationId pageNumber:(NSInteger)pageNumber propertyMap:(NSDictionary *)propertyMap;
 
 - (NSDictionary<NSString *, NSNumber *> *)getPageCropBoxForDocumentViewTag:(NSNumber *)tag pageNumber:(NSInteger)pageNumber;
 

--- a/ios/RNTPTDocumentViewManager.m
+++ b/ios/RNTPTDocumentViewManager.m
@@ -552,21 +552,21 @@ RCT_CUSTOM_VIEW_PROPERTY(annotationPermissionCheckEnabled, BOOL, RNTPTDocumentVi
     }
 }
 
-- (void)setValueForFieldsForDocumentViewTag:(NSNumber *)tag map:(NSDictionary<NSString *, id> *)map
+- (void)setValuesForFieldsForDocumentViewTag:(NSNumber *)tag map:(NSDictionary<NSString *, id> *)map
 {
     RNTPTDocumentView *documentView = self.documentViews[tag];
     if (documentView) {
-        [documentView setValueForFields:map];
+        [documentView setValuesForFields:map];
     } else {
         @throw [NSException exceptionWithName:NSInvalidArgumentException reason:@"Unable to find DocumentView for tag" userInfo:nil];
     }
 }
 
-- (void)setFlagForAnnotationsForDocumentViewTag:(NSNumber *)tag annotationFlagList:(NSArray *)annotationFlagList
+- (void)setFlagsForAnnotationsForDocumentViewTag:(NSNumber *)tag annotationFlagList:(NSArray *)annotationFlagList
 {
     RNTPTDocumentView *documentView = self.documentViews[tag];
     if (documentView) {
-        [documentView setFlagForAnnotations:annotationFlagList];
+        [documentView setFlagsForAnnotations:annotationFlagList];
     } else {
         @throw [NSException exceptionWithName:NSInvalidArgumentException reason:@"Unable to find DocumentView for tag" userInfo:nil];
     }
@@ -582,11 +582,11 @@ RCT_CUSTOM_VIEW_PROPERTY(annotationPermissionCheckEnabled, BOOL, RNTPTDocumentVi
     }
 }
 
-- (void)setPropertyForAnnotation:(NSNumber *)tag annotationId:(NSString *)annotationId pageNumber:(NSInteger)pageNumber propertyMap:(NSDictionary *)propertyMap
+- (void)setPropertiesForAnnotation:(NSNumber *)tag annotationId:(NSString *)annotationId pageNumber:(NSInteger)pageNumber propertyMap:(NSDictionary *)propertyMap
 {
     RNTPTDocumentView *documentView = self.documentViews[tag];
     if (documentView) {
-        [documentView setPropertyForAnnotation:annotationId pageNumber:pageNumber propertyMap:propertyMap];
+        [documentView setPropertiesForAnnotation:annotationId pageNumber:pageNumber propertyMap:propertyMap];
     } else {
         @throw [NSException exceptionWithName:NSInvalidArgumentException reason:@"Unable to find DocumentView for tag" userInfo:nil];
     }

--- a/ios/RNTPTDocumentViewModule.m
+++ b/ios/RNTPTDocumentViewModule.m
@@ -178,14 +178,14 @@ RCT_REMAP_METHOD(setFlagForFields,
     }
 }
 
-RCT_REMAP_METHOD(setValueForFields,
-                 setValueForFieldsForDocumentViewTag:(nonnull NSNumber *)tag
+RCT_REMAP_METHOD(setValuesForFields,
+                 setValuesForFieldsForDocumentViewTag:(nonnull NSNumber *)tag
                  map:(NSDictionary<NSString *, id> *)map
                  resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject)
 {
     @try {
-        [[self documentViewManager] setValueForFieldsForDocumentViewTag:tag map:map];
+        [[self documentViewManager] setValuesForFieldsForDocumentViewTag:tag map:map];
         resolve(nil);
     }
     @catch (NSException *exception) {
@@ -193,14 +193,14 @@ RCT_REMAP_METHOD(setValueForFields,
     }
 }
 
-RCT_REMAP_METHOD(setFlagForAnnotations,
-                 setFlagForAnnotationsForDocumentViewTag:(nonnull NSNumber *)tag
+RCT_REMAP_METHOD(setFlagsForAnnotations,
+                 setFlagsForAnnotationsForDocumentViewTag:(nonnull NSNumber *)tag
                  annotationFlagList:(NSArray *)annotationFlagList
                  resolver:(RCTPromiseResolveBlock)resolve
                  rejecter:(RCTPromiseRejectBlock)reject)
 {
     @try {
-        [[self documentViewManager] setFlagForAnnotationsForDocumentViewTag:tag annotationFlagList:annotationFlagList];
+        [[self documentViewManager] setFlagsForAnnotationsForDocumentViewTag:tag annotationFlagList:annotationFlagList];
         resolve(nil);
     }
     @catch (NSException *exception) {
@@ -224,8 +224,8 @@ RCT_REMAP_METHOD(selectAnnotation,
     }
 }
 
-RCT_REMAP_METHOD(setPropertyForAnnotation,
-                 setPropertyForAnnotationForDocumentViewTag: (nonnull NSNumber *)tag
+RCT_REMAP_METHOD(setPropertiesForAnnotation,
+                 setPropertiesForAnnotationForDocumentViewTag: (nonnull NSNumber *)tag
                  annotationId:(NSString *)annotationId
                  pageNumber:(NSInteger)pageNumber
                  propertyMap:(NSDictionary *)propertyMap
@@ -233,7 +233,7 @@ RCT_REMAP_METHOD(setPropertyForAnnotation,
                  rejector:(RCTPromiseRejectBlock)reject)
 {
     @try {
-        [[self documentViewManager] setPropertyForAnnotation:tag annotationId:annotationId pageNumber:pageNumber propertyMap:propertyMap];
+        [[self documentViewManager] setPropertiesForAnnotation:tag annotationId:annotationId pageNumber:pageNumber propertyMap:propertyMap];
         resolve(nil);
     }
     @catch (NSException *exception) {

--- a/src/DocumentView/DocumentView.js
+++ b/src/DocumentView/DocumentView.js
@@ -247,10 +247,18 @@ export default class DocumentView extends PureComponent {
     return Promise.resolve();
   }
 
+  /**
+  * note: this function exists for supporting the old version. It simply calls setValuesForFields.
+  * 
+  */
   setValueForFields = (fieldsMap) => {
+    return this.setValuesForFields(fieldsMap);
+  }
+
+  setValuesForFields = (fieldsMap) => {
     const tag = findNodeHandle(this._viewerRef);
     if(tag != null) {
-      return DocumentViewManager.setValueForFields(tag, fieldsMap);
+      return DocumentViewManager.setValuesForFields(tag, fieldsMap);
     }
     return Promise.resolve();
   }
@@ -263,10 +271,19 @@ export default class DocumentView extends PureComponent {
     return Promise.resolve();
   }
 
+  
+  /**
+  * note: this function exists for supporting the old version. It simply calls setFlagsForAnnotations.
+  * 
+  */
   setFlagForAnnotations = (annotationFlagList) => {
+    return this.setFlagsForAnnotations(annotationFlagList);  
+  }
+  
+  setFlagsForAnnotations = (annotationFlagList) => {
     const tag = findNodeHandle(this._viewerRef);
     if (tag != null) {
-      return DocumentViewManager.setFlagForAnnotations(tag, annotationFlagList);
+      return DocumentViewManager.setFlagsForAnnotations(tag, annotationFlagList);
     }
     return Promise.resolve();
   }
@@ -279,10 +296,18 @@ export default class DocumentView extends PureComponent {
     return Promise.resolve();
   }
 
+  /**
+  * note: this function exists for supporting the old version. It simply calls setPropertiesForAnnotation.
+  * 
+  */
   setPropertyForAnnotation = (id, pageNumber, propertyMap) => {
+    return setPropertiesForAnnotation(id, pageNumber, propertyMap);
+  }
+
+  setPropertiesForAnnotation = (id, pageNumber, propertyMap) => {
     const tag = findNodeHandle(this._viewerRef);
     if (tag != null) {
-      return DocumentViewManager.setPropertyForAnnotation(tag, id, pageNumber, propertyMap);
+      return DocumentViewManager.setPropertiesForAnnotation(tag, id, pageNumber, propertyMap);
     }
     return Promise.resolve();
   }


### PR DESCRIPTION
Rename 3 functions:

- setValueForFields -> setValuesForFields
- setFlagForAnnotations -> setFlagsForAnnotations
- setPropertyForAnnotation -> setPropertiesForAnnotation

update both Android and iOS, bridge implementations in js (an add notes to old functions), and update README


UPDATE:

For iOS, also do some fixes:

- update importAnnotation

- update the handling of thumbnailViewEditingEnabled