### PR TITLE
enable sticky-note pop-up toggling + annotation type

### DIFF
--- a/API.md
+++ b/API.md
@@ -584,7 +584,7 @@ Parameters:
 Name | Type | Description
 --- | --- | ---
 annotationMenu | string | One of [Config.AnnotationMenu](./src/Config/Config.js) constants, representing which item has been pressed
-annotations | array | An array of `{id, rect}` objects, where `id` is the annotation identifier and `rect={x1, y1, x2, y2}` specifies the annotation's screen rect.
+annotations | array | An array of `{id: string, pageNumber: number, type: string, rect: object}` objects, where `id` is the annotation identifier, `pageNumber` is the page number, type is one of the [Config.Tools](./src/Config/Config.js) constants and `rect={x1, y1, x2, y2}` specifies the annotation's screen rect
 
 ```js
 <DocumentView
@@ -592,6 +592,8 @@ annotations | array | An array of `{id, rect}` objects, where `id` is the annota
     console.log('Annotation menu item', annotationMenu, 'has been pressed');
     annotations.forEach(annotation => {
       console.log('The id of selected annotation is', annotation.id);
+      console.log('The page number of selected annotation is', annotation.pageNumber);
+      console.log('The type of selected annotation is', annotation.type);
       console.log('The lower left corner of selected annotation is', annotation.x1, annotation.y1);
     });
   }}
@@ -683,9 +685,10 @@ data | object | A JSON object that varies depending on the action
 
 Data param table:
 
-Action | Param
+Action | Data param
 --- | ---
-[`Config.Actions.linkPress`](./src/Config/Config.js) | key: `url`, value: the link pressed
+[`Config.Actions.linkPress`](./src/Config/Config.js) | `{url: string}`
+[`Config.Actions.stickyNoteShowPopUp`](./src/Config/Config.js) | `{id: string, pageNumber: number, type: string, rect: {x1: number, y1: number, x2: number, y2: number}}`
 
 ```js
 <DocumentView
@@ -693,6 +696,8 @@ Action | Param
     console.log('Activated action is', action);
     if (action === Config.Actions.linkPress) {
       console.log('The external link pressed is', data.url);
+    } else if (action === Config.Actions.stickyNoteShowPopUp) {
+      console.log('Sticky note has been activated, but it would not show a pop up window.');
     }
   }}
 />
@@ -850,7 +855,7 @@ Parameters:
 
 Name | Type | Description
 --- | --- | ---
-annotations | array | array of annotation data in the format `{id: string, pageNumber: number, rect: {x1: number, y1: number, x2: number, y2: number}}`, representing the selected annotations
+annotations | array | array of annotation data in the format `{id: string, pageNumber: number, type: string, rect: {x1: number, y1: number, x2: number, y2: number}}`, representing the selected annotations. Type is one of the [Config.Tools](./src/Config/Config.js) constants
 
 ```js
 <DocumentView
@@ -858,6 +863,7 @@ annotations | array | array of annotation data in the format `{id: string, pageN
     annotations.forEach(annotation => {
       console.log('The id of selected annotation is', annotation.id);
       console.log('It is in page', annotation.pageNumber);
+      console.log('Its type is', annotation.type);
       console.log('Its lower left corner has coordinate', annotation.rect.x1, annotation.rect.y1);
     });
   }}
@@ -874,7 +880,7 @@ Parameters:
 Name | Type | Description
 --- | --- | ---
 action | string | the action that occurred (add, delete, modify)
-annotations | array | array of annotation data in the format `{id: string, pageNumber: number}`, representing the annotations that have been changed
+annotations | array | array of annotation data in the format `{id: string, pageNumber: number, type: string}`, representing the annotations that have been changed. Type is one of the [Config.Tools](./src/Config/Config.js) constants
 
 ```js
 <DocumentView
@@ -883,6 +889,7 @@ annotations | array | array of annotation data in the format `{id: string, pageN
     annotations.forEach(annotation => {
       console.log('The id of changed annotation is', annotation.id);
       console.log('It is in page', annotation.pageNumber);
+      console.log('Its type is', annotation.type);
     });
   }}
 />

--- a/android/src/main/java/com/pdftron/reactnative/utils/Constants.java
+++ b/android/src/main/java/com/pdftron/reactnative/utils/Constants.java
@@ -237,6 +237,7 @@ public final class Constants {
     public static final String KEY_ANNOTATION_TITLE = "title";
     public static final String KEY_ANNOTATION_CONTENTS = "contents";
     public static final String KEY_ANNOTATION_CONTENT_RECT = "contentRect";
+    public static final String KEY_ANNOTATION_TYPE = "type";
 
     public static final String KEY_ACTION = "action";
     public static final String KEY_ACTION_ADD = "add";
@@ -282,4 +283,5 @@ public final class Constants {
 
     // Config keys
     public static final String KEY_CONFIG_LINK_PRESS = "linkPress";
+    public static final String KEY_CONFIG_STICKY_NOTE_SHOW_POP_UP = "stickyNoteShowPopUp";
 }

--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -454,6 +454,9 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
 
     public void setOverrideBehavior(@NonNull ReadableArray items) {
         mActionOverrideItems = items;
+        if (getToolManager() != null) {
+            getToolManager().setStickyNoteShowPopup(!isOverrideAction(KEY_CONFIG_STICKY_NOTE_SHOW_POP_UP));
+        }
     }
 
     public void setSignSignatureFieldsWithStamps(boolean signWithStamps) {
@@ -741,6 +744,93 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
         }
         return annotType;
     }
+
+    @Nullable
+    private String convAnnotTypeToString(int annotType) {
+        String annotString;
+        switch (annotType) {
+            case Annot.e_Ink:
+                annotString = TOOL_ANNOTATION_CREATE_FREE_HAND;
+                break;
+            case Annot.e_Highlight:
+                annotString = TOOL_ANNOTATION_CREATE_TEXT_HIGHLIGHT;
+                break;
+            case Annot.e_Underline:
+                annotString = TOOL_ANNOTATION_CREATE_TEXT_UNDERLINE;
+                break;
+            case Annot.e_Squiggly:
+                annotString = TOOL_ANNOTATION_CREATE_TEXT_SQUIGGLY;
+                break;
+            case Annot.e_StrikeOut:
+                annotString = TOOL_ANNOTATION_CREATE_TEXT_STRIKEOUT;
+                break;
+            case Annot.e_Square:
+                annotString = TOOL_ANNOTATION_CREATE_RECTANGLE;
+                break;
+            case Annot.e_Circle:
+                annotString = TOOL_ANNOTATION_CREATE_ELLIPSE;
+                break;
+            case Annot.e_Line:
+                annotString = TOOL_ANNOTATION_CREATE_LINE;
+                break;
+            case Annot.e_Polyline:
+                annotString = TOOL_ANNOTATION_CREATE_POLYLINE;
+                break;
+            case Annot.e_Polygon:
+                annotString = TOOL_ANNOTATION_CREATE_POLYGON;
+                break;
+            case AnnotStyle.CUSTOM_ANNOT_TYPE_CLOUD:
+                annotString = TOOL_ANNOTATION_CREATE_POLYGON_CLOUD;
+                break;
+            case AnnotStyle.CUSTOM_ANNOT_TYPE_SIGNATURE:
+                annotString = TOOL_ANNOTATION_CREATE_SIGNATURE;
+                break;
+            case Annot.e_FreeText:
+                annotString = TOOL_ANNOTATION_CREATE_FREE_TEXT;
+                break;
+            case Annot.e_Text:
+                annotString = TOOL_ANNOTATION_CREATE_STICKY;
+                break;
+            case AnnotStyle.CUSTOM_ANNOT_TYPE_CALLOUT:
+                annotString = TOOL_ANNOTATION_CREATE_CALLOUT;
+                break;
+            case Annot.e_Stamp:
+                annotString = TOOL_ANNOTATION_CREATE_STAMP;
+                break;
+            case AnnotStyle.CUSTOM_ANNOT_TYPE_RULER:
+                annotString = TOOL_ANNOTATION_CREATE_DISTANCE_MEASUREMENT;
+                break;
+            case AnnotStyle.CUSTOM_ANNOT_TYPE_PERIMETER_MEASURE:
+                annotString = TOOL_ANNOTATION_CREATE_PERIMETER_MEASUREMENT;
+                break;
+            case AnnotStyle.CUSTOM_ANNOT_TYPE_AREA_MEASURE:
+                annotString = TOOL_ANNOTATION_CREATE_AREA_MEASUREMENT;
+                break;
+            case Annot.e_FileAttachment:
+                annotString = TOOL_ANNOTATION_CREATE_FILE_ATTACHMENT;
+                break;
+            case Annot.e_Sound:
+                annotString = TOOL_ANNOTATION_CREATE_SOUND;
+                break;
+            case Annot.e_Redact:
+                annotString = TOOL_ANNOTATION_CREATE_LINK_TEXT;
+                break;
+            case Annot.e_Link:
+                annotString = TOOL_ANNOTATION_CREATE_LINK;
+                break;
+            case AnnotStyle.CUSTOM_ANNOT_TYPE_FREE_HIGHLIGHTER:
+                annotString = TOOL_ANNOTATION_CREATE_FREE_HIGHLIGHTER;
+                break;
+            case Annot.e_Widget:
+                annotString = TOOL_FORM_CREATE_TEXT_FIELD;
+                break;
+            default:
+                annotString = "";
+                break;
+        }
+        return annotString;
+    }
+
 
     @Nullable
     private ToolManager.ToolMode convStringToToolMode(String item) {
@@ -1368,6 +1458,7 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
         if (null == mFragmentManager) {
             setSupportFragmentManager(mFragmentManagerSave);
         }
+
         // TODO, update base64 when ViewerBuilder supports byte array
         Uri fileUri = ReactUtils.getUri(getContext(), mDocumentPath, mIsBase64, mBase64Extension);
 
@@ -1469,44 +1560,65 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
         return mSelectedAnnots != null && !mSelectedAnnots.isEmpty();
     }
 
-    private WritableArray getAnnotationsData() {
+    private WritableArray getAnnotationsData(boolean overrideAction) {
+        // overrideAction is for onBehaviorActivated
         WritableArray annots = Arguments.createArray();
 
         for (Map.Entry<Annot, Integer> entry : mSelectedAnnots.entrySet()) {
-            Annot key = entry.getKey();
-            Integer value = entry.getValue();
+            WritableMap annotationData = getAnnotationData(entry.getKey(), entry.getValue());
 
-            WritableMap annotPair = Arguments.createMap();
+            if (annotationData != null) {
+                annots.pushMap(annotationData);
+                if (overrideAction && isOverrideAction(KEY_CONFIG_STICKY_NOTE_SHOW_POP_UP)) {
+                    try {
+                        if (entry.getKey().getType() == Annot.e_Text) {
+                            WritableMap params = Arguments.createMap();
 
-            // try to obtain id
-            String uid = null;
-            try {
-                uid = key.getUniqueID() != null ? key.getUniqueID().getAsPDFText() : null;
-            } catch (Exception e) {
-                e.printStackTrace();
-            }
-            if (uid != null) {
-                annotPair.putString(KEY_ANNOTATION_ID, uid);
-                annotPair.putInt(KEY_ANNOTATION_PAGE, value);
-                // try to obtain bbox
-                try {
-                    com.pdftron.pdf.Rect bbox = getPdfViewCtrl().getScreenRectForAnnot(key, value);
-                    WritableMap bboxMap = Arguments.createMap();
-                    bboxMap.putDouble(KEY_X1, bbox.getX1());
-                    bboxMap.putDouble(KEY_Y1, bbox.getY1());
-                    bboxMap.putDouble(KEY_X2, bbox.getX2());
-                    bboxMap.putDouble(KEY_Y2, bbox.getY2());
-                    bboxMap.putDouble(KEY_WIDTH, bbox.getWidth());
-                    bboxMap.putDouble(KEY_HEIGHT, bbox.getHeight());
-                    annotPair.putMap(KEY_ANNOTATION_RECT, bboxMap);
-                } catch (Exception ex) {
-                    ex.printStackTrace();
+                            params.putString(ON_BEHAVIOR_ACTIVATED, ON_BEHAVIOR_ACTIVATED);
+                            params.putString(KEY_ACTION, KEY_CONFIG_STICKY_NOTE_SHOW_POP_UP);
+                            params.putMap(KEY_DATA, annotationData);
+
+                            onReceiveNativeEvent(params);
+                        }
+                    } catch (PDFNetException e) {
+                        e.printStackTrace();
+                    }
                 }
-
-                annots.pushMap(annotPair);
             }
         }
         return annots;
+    }
+
+    private WritableMap getAnnotationData(Annot annot, int pageNumber) {
+        WritableMap annotPair = Arguments.createMap();
+
+        // try to obtain id
+        String uid = null;
+        try {
+            uid = annot.getUniqueID() != null ? annot.getUniqueID().getAsPDFText() : null;
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        annotPair.putString(KEY_ANNOTATION_ID, uid == null ? "" : uid);
+        annotPair.putInt(KEY_ANNOTATION_PAGE, pageNumber);
+        // try to obtain bbox and type
+        try {
+            annotPair.putString(KEY_ANNOTATION_TYPE, convAnnotTypeToString(annot.getType()));
+            com.pdftron.pdf.Rect bbox = getPdfViewCtrl().getScreenRectForAnnot(annot, pageNumber);
+            WritableMap bboxMap = Arguments.createMap();
+            bboxMap.putDouble(KEY_X1, bbox.getX1());
+            bboxMap.putDouble(KEY_Y1, bbox.getY1());
+            bboxMap.putDouble(KEY_X2, bbox.getX2());
+            bboxMap.putDouble(KEY_Y2, bbox.getY2());
+            bboxMap.putDouble(KEY_WIDTH, bbox.getWidth());
+            bboxMap.putDouble(KEY_HEIGHT, bbox.getHeight());
+            annotPair.putMap(KEY_ANNOTATION_RECT, bboxMap);
+        } catch (Exception ex) {
+            ex.printStackTrace();
+        }
+
+        return annotPair;
     }
 
     private ToolManager.QuickMenuListener mQuickMenuListener = new ToolManager.QuickMenuListener() {
@@ -1528,7 +1640,7 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
                         WritableMap params = Arguments.createMap();
                         params.putString(ON_ANNOTATION_MENU_PRESS, ON_ANNOTATION_MENU_PRESS);
                         params.putString(KEY_ANNOTATION_MENU, menuStr);
-                        params.putArray(KEY_ANNOTATIONS, getAnnotationsData());
+                        params.putArray(KEY_ANNOTATIONS, getAnnotationsData(false));
                         onReceiveNativeEvent(params);
                     } catch (Exception ex) {
                         ex.printStackTrace();
@@ -1627,10 +1739,12 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
             if (hasAnnotationsSelected() && getPdfViewCtrl() != null && getToolManager() != null) {
                 try {
                     // notify event
+                    WritableArray annotationsData = getAnnotationsData(true);
                     WritableMap params = Arguments.createMap();
                     params.putString(ON_ANNOTATIONS_SELECTED, ON_ANNOTATIONS_SELECTED);
-                    params.putArray(KEY_ANNOTATIONS, getAnnotationsData());
+                    params.putArray(KEY_ANNOTATIONS, annotationsData);
                     onReceiveNativeEvent(params);
+
                 } catch (Exception ex) {
                     ex.printStackTrace();
                 }
@@ -1884,13 +1998,16 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
             } catch (Exception e) {
                 e.printStackTrace();
             }
-            if (uid != null) {
-                Integer value = entry.getValue();
-                WritableMap annotData = Arguments.createMap();
-                annotData.putString(KEY_ANNOTATION_ID, uid);
-                annotData.putInt(KEY_ANNOTATION_PAGE, value);
-                annotList.pushMap(annotData);
+
+            WritableMap annotData = Arguments.createMap();
+            annotData.putString(KEY_ANNOTATION_ID, uid == null ? "" : uid);
+            annotData.putInt(KEY_ANNOTATION_PAGE, entry.getValue());
+            try {
+                annotData.putString(KEY_ANNOTATION_TYPE, convAnnotTypeToString(key.getType()));
+            } catch (PDFNetException e) {
+                e.printStackTrace();
             }
+            annotList.pushMap(annotData);
         }
 
         params.putArray(KEY_ANNOTATIONS, annotList);
@@ -1942,6 +2059,10 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
     @Override
     public void onTabDocumentLoaded(String tag) {
         super.onTabDocumentLoaded(tag);
+
+        if (getToolManager() != null) {
+            getToolManager().setStickyNoteShowPopup(!isOverrideAction(KEY_CONFIG_STICKY_NOTE_SHOW_POP_UP));
+        }
 
         if (mInitialPageNumber > 0) {
             try {

--- a/ios/RNTPTDocumentView.h
+++ b/ios/RNTPTDocumentView.h
@@ -118,6 +118,7 @@ static NSString * const PTAnnotationIdKey = @"id";
 static NSString * const PTAnnotationPageNumberKey = @"pageNumber";
 static NSString * const PTAnnotationFlagKey = @"flag";
 static NSString * const PTAnnotationFlagValueKey = @"flagValue";
+static NSString * const PTAnnotationTypeKey = @"type";
 
 static NSString * const PTContentRectAnnotationPropertyKey = @"contentRect";
 static NSString * const PTContentsAnnotationPropertyKey = @"contents";
@@ -127,8 +128,11 @@ static NSString * const PTTitleAnnotationPropertyKey = @"title";
 static NSString * const PTLinkPressLinkAnnotationKey = @"linkPress";
 static NSString * const PTURILinkAnnotationKey = @"URI";
 static NSString * const PTURLLinkAnnotationKey = @"url";
-static NSString * const PTDataLinkAnnotationKey = @"data";
-static NSString * const PTActionLinkAnnotationKey = @"action";
+
+static NSString * const PTStickyNoteShowPopUpKey = @"stickyNoteShowPopUp";
+
+static NSString * const PTDataBehaviorKey = @"data";
+static NSString * const PTActionBehaviorKey = @"action";
 
 static NSString * const PTStyleMenuItemTitleKey = @"Style";
 static NSString * const PTNoteMenuItemTitleKey = @"Note";
@@ -234,6 +238,8 @@ static const PTAnnotationToolbarKey PTAnnotationToolbarKeyItems = @"items";
 - (void)bookmarkChanged:(RNTPTDocumentView *)sender bookmarkJson:(NSString *)bookmarkJson;
 
 - (void)toolChanged:(RNTPTDocumentView *)sender previousTool:(NSString *)previousTool tool:(NSString *)tool;
+
+- (void)behaviorActivated:(RNTPTDocumentView *)sender action:(NSString *)action data:(NSDictionary *)data;
 
 @end
 

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -1556,6 +1556,9 @@ NS_ASSUME_NONNULL_END
     // Select after creation.
     toolManager.selectAnnotationAfterCreation = self.selectAnnotationAfterCreation;
     
+    // Sticky note pop up.
+    toolManager.textAnnotationOptions.opensPopupOnTap = ![self.overrideBehavior containsObject:PTStickyNoteShowPopUpKey];
+    
     // Auto save.
     documentViewController.automaticallySavesDocument = self.autoSaveEnabled;
     
@@ -2167,13 +2170,12 @@ NS_ASSUME_NONNULL_END
         NSLog(@"%@", error);
     }
     if (url) {
-        self.onChange(@{
-            @"onBehaviorActivated": @"onBehaviorActivated",
-            PTActionLinkAnnotationKey: PTLinkPressLinkAnnotationKey,
-            PTDataLinkAnnotationKey: @{
+        
+        if ([self.delegate respondsToSelector:@selector(behaviorActivated:action:data:)]) {
+            [self.delegate behaviorActivated:self action:PTLinkPressLinkAnnotationKey data:@{
                 PTURLLinkAnnotationKey: url,
-            },
-        });
+            }];
+        }
         
         // Link handled.
         return NO;
@@ -2236,48 +2238,68 @@ NS_ASSUME_NONNULL_END
     return !self.hideTopAppNavBar;
 }
 
-- (NSArray<NSDictionary<NSString *, id> *> *)annotationDataForAnnotations:(NSArray<PTAnnot *> *)annotations pageNumber:(int)pageNumber pdfViewCtrl:(PTPDFViewCtrl *)pdfViewCtrl
+- (NSDictionary<NSString *, id> *)getAnnotationData:(PTAnnot *)annot pageNumber:(int)pageNumber pdfViewCtrl:(PTPDFViewCtrl *)pdfViewCtrl {
+    if (![annot IsValid]) {
+        return nil;
+    }
+    
+    NSString *uniqueId = nil;
+    
+    PTObj *uniqueIdObj = [annot GetUniqueID];
+    if ([uniqueIdObj IsValid] && [uniqueIdObj IsString]) {
+        uniqueId = [uniqueIdObj GetAsPDFText];
+    }
+    
+    PTPDFRect *screenRect = [pdfViewCtrl GetScreenRectForAnnot:annot
+                                                      page_num:pageNumber];
+    
+    NSString *annotationType = [RNTPTDocumentView stringForAnnotType:[annot GetType]];
+    
+    return @{
+        PTAnnotationIdKey: (uniqueId ?: @""),
+        PTAnnotationPageNumberKey: @(pageNumber),
+        PTAnnotationTypeKey: annotationType,
+        PTRectKey: @{
+                PTRectX1Key: @([screenRect GetX1]),
+                PTRectY1Key: @([screenRect GetY1]),
+                PTRectX2Key: @([screenRect GetX2]),
+                PTRectY2Key: @([screenRect GetY2]),
+        },
+    };
+}
+
+- (NSArray<NSDictionary<NSString *, id> *> *)annotationDataForAnnotations:(NSArray<PTAnnot *> *)annotations pageNumber:(int)pageNumber pdfViewCtrl:(PTPDFViewCtrl *)pdfViewCtrl overrideAction:(bool)overrideAction
 {
-    NSMutableArray<NSDictionary<NSString *, id> *> *annotationData = [NSMutableArray array];
+    NSMutableArray<NSDictionary<NSString *, id> *> *annotationsData = [NSMutableArray array];
     
     if (annotations.count > 0) {
         [pdfViewCtrl DocLockReadWithBlock:^(PTPDFDoc *doc) {
             for (PTAnnot *annot in annotations) {
-                if (![annot IsValid]) {
-                    continue;
+                NSDictionary *annotDict = [self getAnnotationData:annot pageNumber:pageNumber pdfViewCtrl:pdfViewCtrl];
+                
+                if (annotDict) {
+                    [annotationsData addObject:annotDict];
+                    
+                    if (overrideAction && [self.overrideBehavior containsObject:PTStickyNoteShowPopUpKey]) {
+                        if ([self.delegate respondsToSelector:@selector(behaviorActivated:action:data:)]) {
+                            [self.delegate behaviorActivated:self action:PTStickyNoteShowPopUpKey data: annotDict];
+                        }
+                    }
                 }
-                
-                NSString *uniqueId = nil;
-                
-                PTObj *uniqueIdObj = [annot GetUniqueID];
-                if ([uniqueIdObj IsValid] && [uniqueIdObj IsString]) {
-                    uniqueId = [uniqueIdObj GetAsPDFText];
-                }
-                
-                PTPDFRect *screenRect = [pdfViewCtrl GetScreenRectForAnnot:annot
-                                                                  page_num:pageNumber];
-                [annotationData addObject:@{
-                    PTAnnotationIdKey: (uniqueId ?: @""),
-                    PTAnnotationPageNumberKey: @(pageNumber),
-                    PTRectKey: @{
-                            PTRectX1Key: @([screenRect GetX1]),
-                            PTRectY1Key: @([screenRect GetY1]),
-                            PTRectX2Key: @([screenRect GetX2]),
-                            PTRectY2Key: @([screenRect GetY2]),
-                    },
-                }];
             }
         } error:nil];
     }
 
-    return [annotationData copy];
+    return [annotationsData copy];
 }
+
+
 
 - (void)rnt_documentViewController:(PTDocumentBaseViewController *)documentViewController didSelectAnnotations:(NSArray<PTAnnot *> *)annotations onPageNumber:(int)pageNumber
 {
     PTPDFViewCtrl *pdfViewCtrl = documentViewController.pdfViewCtrl;
 
-    NSArray<NSDictionary<NSString *, id> *> *annotationData = [self annotationDataForAnnotations:annotations pageNumber:pageNumber pdfViewCtrl:pdfViewCtrl];
+    NSArray<NSDictionary<NSString *, id> *> *annotationData = [self annotationDataForAnnotations:annotations pageNumber:pageNumber pdfViewCtrl:pdfViewCtrl overrideAction:YES];
     
     if ([self.delegate respondsToSelector:@selector(annotationsSelected:annotations:)]) {
         [self.delegate annotationsSelected:self annotations:annotationData];
@@ -2447,7 +2469,7 @@ NS_ASSUME_NONNULL_END
     
     const int pageNumber = toolManager.tool.annotationPageNumber;
     
-    NSArray<NSDictionary<NSString *, id> *> *annotationData = [self annotationDataForAnnotations:annotations pageNumber:pageNumber pdfViewCtrl:pdfViewCtrl];
+    NSArray<NSDictionary<NSString *, id> *> *annotationData = [self annotationDataForAnnotations:annotations pageNumber:pageNumber pdfViewCtrl:pdfViewCtrl overrideAction:NO];
         
     if ([self.delegate respondsToSelector:@selector(annotationMenuPressed:annotationMenu:annotations:)]) {
         [self.delegate annotationMenuPressed:self annotationMenu:menuItemId annotations:annotationData];
@@ -2638,6 +2660,7 @@ NS_ASSUME_NONNULL_END
         [self.delegate annotationChanged:self annotation:@{
             PTAnnotationIdKey: annotId,
             PTAnnotationPageNumberKey: @(pageNumber),
+            PTAnnotationTypeKey: [RNTPTDocumentView stringForAnnotType:[annot GetType]],
         } action:PTAddAnnotationActionKey];
     }
     if (!self.collaborationManager) {
@@ -2664,6 +2687,7 @@ NS_ASSUME_NONNULL_END
     if ([self.delegate respondsToSelector:@selector(annotationChanged:annotation:action:)]) {
         [self.delegate annotationChanged:self annotation:@{
             PTAnnotationIdKey: annotId,
+            PTAnnotationTypeKey: [RNTPTDocumentView stringForAnnotType:[annot GetType]],
             PTAnnotationPageNumberKey: @(pageNumber),
         } action:PTModifyAnnotationActionKey];
     }
@@ -2692,6 +2716,7 @@ NS_ASSUME_NONNULL_END
         [self.delegate annotationChanged:self annotation:@{
             PTAnnotationIdKey: annotId,
             PTAnnotationPageNumberKey: @(pageNumber),
+            PTAnnotationTypeKey: [RNTPTDocumentView stringForAnnotType:[annot GetType]],
         } action:PTRemoveAnnotationActionKey];
     }
     if (!self.collaborationManager) {
@@ -3000,7 +3025,7 @@ NS_ASSUME_NONNULL_END
 + (Class)toolClassForKey:(NSString *)key
 {
     if ([key isEqualToString:PTAnnotationEditToolKey]) {
-        return [PTAnnotSelectTool class];
+        return [PTAnnotEditTool class];
     }
     else if ([key isEqualToString:PTAnnotationCreateStickyToolKey] ||
              [key isEqualToString:PTStickyToolButtonKey]) {
@@ -3139,10 +3164,10 @@ NS_ASSUME_NONNULL_END
 
 + (NSString *)keyForToolClass:(Class)toolClass
 {
-    if (toolClass == [PTAnnotSelectTool class]) {
+    if (toolClass == [PTAnnotEditTool class]) {
         return PTAnnotationEditToolKey;
     }
-    else if (toolClass == [PTAnnotationCreateStickyToolKey class]) {
+    else if (toolClass == [PTStickyNoteCreate class]) {
         return PTAnnotationCreateStickyToolKey;
     }
     else if (toolClass == [PTFreeHandCreate class]) {
@@ -3159,6 +3184,9 @@ NS_ASSUME_NONNULL_END
     }
     else if (toolClass == [PTTextSquigglyCreate class]) {
         return PTAnnotationCreateTextSquigglyToolKey;
+    }
+    else if (toolClass == [PTTextStrikeoutCreate class]) {
+        return PTAnnotationCreateTextStrikeoutToolKey;
     }
     else if (toolClass == [PTFreeTextCreate class]) {
         return PTAnnotationCreateFreeTextToolKey;
@@ -3211,17 +3239,17 @@ NS_ASSUME_NONNULL_END
     else if (toolClass == [PTFreeHandHighlightCreate class]) {
         return PTAnnotationCreateFreeHighlighterToolKey;
     }
+    else if (toolClass == [PTPanTool class]) {
+        return PTPanToolKey;
+    }
     else if (toolClass == [PTRubberStampCreate class]) {
-        return PTAnnotationCreateFreeHighlighterToolKey;
+        return PTAnnotationCreateRubberStampToolKey;
     }
     else if (toolClass == [PTRectangleRedactionCreate class]) {
         return PTAnnotationCreateRedactionToolKey;
     }
     else if (toolClass == [PTTextRedactionCreate class]) {
         return PTAnnotationCreateRedactionTextToolKey;
-    }
-    else if (toolClass == [PTPanTool class]) {
-        return PTPanToolKey;
     }
     
     if (@available(iOS 13.1, *)) {
@@ -3231,6 +3259,70 @@ NS_ASSUME_NONNULL_END
     }
     
     return Nil;
+}
+
++ (NSString *)stringForAnnotType:(PTAnnotType)type {
+    if (type == e_ptText) {
+        return PTAnnotationCreateStickyToolKey;
+    } else if (type == e_ptLink) {
+        return PTAnnotationCreateLinkToolKey;
+    } else if (type == e_ptFreeText) {
+        return PTAnnotationCreateFreeTextToolKey;
+    } else if (type == e_ptLine) {
+        return PTAnnotationCreateLineToolKey;
+    } else if (type == e_ptSquare) {
+        return PTAnnotationCreateRectangleToolKey;
+    } else if (type == e_ptCircle) {
+        return PTAnnotationCreateEllipseToolKey;
+    } else if (type == e_ptPolygon) {
+        return PTAnnotationCreatePolygonToolKey;
+    } else if (type == e_ptPolyline) {
+        return PTAnnotationCreatePolylineToolKey;
+    } else if (type == e_ptHighlight) {
+        return PTAnnotationCreateFreeHighlighterToolKey;
+    } else if (type == e_ptUnderline) {
+        return PTAnnotationCreateTextUnderlineToolKey;
+    } else if (type == e_ptSquiggly) {
+        return PTAnnotationCreateTextSquigglyToolKey;
+    } else if (type == e_ptStrikeOut) {
+        return PTAnnotationCreateTextStrikeoutToolKey;
+    } else if (type == e_ptStamp) {
+        return PTAnnotationCreateStampToolKey;
+    } else if (type == e_ptCaret) {
+        return @"";
+    } else if (type == e_ptInk) {
+        return PTAnnotationCreateFreeHandToolKey;
+    } else if (type == e_ptPopup) {
+        return @"";
+    } else if (type == e_ptFileAttachment) {
+        return PTAnnotationCreateFileAttachmentToolKey;
+    } else if (type == e_ptSound) {
+        return PTAnnotationCreateSoundToolKey;
+    } else if (type == e_ptMovie) {
+        return @"";
+    } else if (type == e_ptWidget) {
+        return PTFormCreateTextFieldToolKey;
+    } else if (type == e_ptScreen) {
+        return @"";
+    } else if (type == e_ptPrinterMark) {
+        return @"";
+    } else if (type == e_ptTrapNet) {
+        return @"";
+    } else if (type == e_ptWatermark) {
+        return @"";
+    } else if (type == e_pt3D) {
+        return @"";
+    } else if (type == e_ptRedact) {
+        return PTAnnotationCreateRedactionToolKey;
+    } else if (type == e_ptProjection) {
+        return @"";
+    } else if (type == e_ptRichMedia) {
+        return @"";
+    } else if (type == e_ptUnknown) {
+        return @"";
+    }
+    
+    return @"";
 }
 
 + (NSURL *)PT_getFileURL:(NSString *)document

--- a/ios/RNTPTDocumentViewManager.m
+++ b/ios/RNTPTDocumentViewManager.m
@@ -538,6 +538,16 @@ RCT_CUSTOM_VIEW_PROPERTY(hideThumbnailFilterModes, NSArray, RNTPTDocumentView)
     }
 }
 
+- (void)behaviorActivated:(RNTPTDocumentView *)sender action:(NSString *)action data:(NSDictionary *)data {
+    if (sender.onChange) {
+        sender.onChange(@{
+            @"onBehaviorActivated": @"onBehaviorActivated",
+            @"action": action,
+            @"data": data,
+        });
+    }
+}
+
 #pragma mark - Methods
 
 - (void)setToolModeForDocumentViewTag:(NSNumber *)tag toolMode:(NSString *)toolMode

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "2.0.3-beta.51",
+  "version": "2.0.3-beta.52",
   "description": "React Native Pdftron",
   "main": "index.js",
   "scripts": {

--- a/src/Config/Config.js
+++ b/src/Config/Config.js
@@ -142,6 +142,7 @@ export default {
   // Actions define potentially overridable action to the viewer
   Actions: {
     linkPress: 'linkPress',
+    stickyNoteShowPopUp: 'stickyNoteShowPopUp',
   },
 
   // AnnotationFlags define the flags for any annotation in the document


### PR DESCRIPTION
sticky-note pop-up could be disabled by overrideBehavior. It would call onBehaviorActivated if selected.

Annotation type is now added as part of the promise result for onAnnotationsSelected, onAnnotationChanged and onQuickMenuButtonPressed.