### PR TITLE
[IOS] Custom toolbar buttons and moreItemsToolbar

### DIFF
--- a/API.md
+++ b/API.md
@@ -431,7 +431,7 @@ Defines whether an unhandled tap in the viewer should toggle the visibility of t
 #### topAppNavBarRightBar
 array of strings, optional, iOS only
 
-Customizes the right bar section of the top app nav bar. If passed in, the default right bar section will not be used. Strings should be [Config.Buttons](./src/Config/Config.js) constants.
+Customizes the right bar section of the top app nav bar. If passed in, the default right bar section will not be used. Strings should be [Config.Buttons](./src/Config/Config.js) constants or [Config.CustomToolbarButonKey](./src/Config/Config.js).
 
 ```js
 <Documentview
@@ -442,11 +442,41 @@ Customizes the right bar section of the top app nav bar. If passed in, the defau
 #### bottomToolbar
 array of strings, optional, iOS only
 
-Defines a custom bottom toolbar. If passed in, the default bottom toolbar will not be used. Strings should be [Config.Buttons](./src/Config/Config.js) constants.
+Defines a custom bottom toolbar. If passed in, the default bottom toolbar will not be used. Strings should be [Config.Buttons](./src/Config/Config.js) constants or [Config.CustomToolbarButonKey](./src/Config/Config.js).
 
 ```js
 <Documentview
   bottomToolbar={[Config.Buttons.reflowButton, Config.Buttons.outlineListButton]}
+/>
+```
+
+#### moreItemsToolbar
+array of strings, optional, iOS only
+
+Defines a custom more items toolbar. If passed in, the default more items toolbar will not be used. Strings should be [Config.Buttons](./src/Config/Config.js) constants or [Config.CustomToolbarButonKey](./src/Config/Config.js).
+
+```js
+<Documentview
+  moreItemsToolbar={[Config.Buttons.reflowButton, Config.Buttons.outlineListButton]}
+/>
+```
+
+#### onCustomToolbarButtonPressed
+function, optional
+
+This function is called when a custom toolbar button is pressed.
+
+Parameters:
+
+Name | Type | Description
+--- | --- | ---
+toolbar | object | the custom toolbar button object that was pressed
+
+```js
+<DocumentView
+  onCustomToolbarButtonPressed={toolbar => {
+    console.log('Custom toolbar button pressed:', toolbar);
+  }
 />
 ```
 

--- a/ios/RNTPTDocumentView.h
+++ b/ios/RNTPTDocumentView.h
@@ -228,7 +228,7 @@ static const PTCustomToolbarButonKey PTCustomToolbarButonKeySelected = @"selecte
 - (void)documentViewDetachedFromWindow:(RNTPTDocumentView *)documentView;
 
 - (void)navButtonClicked:(RNTPTDocumentView *)sender;
-- (void)customToolbarPressed:(RNTPTDocumentView *)sender toolbar:(NSDictionary<NSString *, id> *)toolbar;
+- (void)customToolbarButtonPressed:(RNTPTDocumentView *)sender toolbar:(NSDictionary<NSString *, id> *)toolbar;
 - (void)documentLoaded:(RNTPTDocumentView *)sender;
 - (void)documentError:(RNTPTDocumentView *)sender error:(nullable NSString *)error;
 - (void)pageChanged:(RNTPTDocumentView *)sender previousPageNumber:(int)previousPageNumber;

--- a/ios/RNTPTDocumentView.h
+++ b/ios/RNTPTDocumentView.h
@@ -337,6 +337,7 @@ static const PTCustomToolbarButonKey PTCustomToolbarButonKeySelected = @"selecte
 @property (nonatomic, copy, nullable) NSArray<NSString *> *hideDefaultAnnotationToolbars;
 @property (nonatomic, copy, nullable) NSArray<NSString *> *topAppNavBarRightBar;
 @property (nonatomic, copy, nullable) NSArray<NSString *> *bottomToolbar;
+@property (nonatomic, copy, nullable) NSArray<NSString *> *moreItemsToolbar;
 
 @property (nonatomic) BOOL hideAnnotationToolbarSwitcher;
 @property (nonatomic) BOOL hideTopToolbars;

--- a/ios/RNTPTDocumentView.h
+++ b/ios/RNTPTDocumentView.h
@@ -213,6 +213,13 @@ static const PTAnnotationToolbarKey PTAnnotationToolbarKeyName = @"name";
 static const PTAnnotationToolbarKey PTAnnotationToolbarKeyIcon = @"icon";
 static const PTAnnotationToolbarKey PTAnnotationToolbarKeyItems = @"items";
 
+// Custom bottom toolbar keys.
+typedef NSString * PTCustomToolbarButonKey;
+static const PTCustomToolbarButonKey PTCustomToolbarButonKeyId = @"id";
+static const PTCustomToolbarButonKey PTCustomToolbarButonKeyName = @"name";
+static const PTCustomToolbarButonKey PTCustomToolbarButonKeyIcon = @"icon";
+static const PTCustomToolbarButonKey PTCustomToolbarButonKeySelected = @"selected";
+
 @class RNTPTDocumentView;
 
 @protocol RNTPTDocumentViewDelegate <NSObject>
@@ -221,6 +228,7 @@ static const PTAnnotationToolbarKey PTAnnotationToolbarKeyItems = @"items";
 - (void)documentViewDetachedFromWindow:(RNTPTDocumentView *)documentView;
 
 - (void)navButtonClicked:(RNTPTDocumentView *)sender;
+- (void)customToolbarPressed:(RNTPTDocumentView *)sender toolbar:(NSDictionary<NSString *, id> *)toolbar;
 - (void)documentLoaded:(RNTPTDocumentView *)sender;
 - (void)documentError:(RNTPTDocumentView *)sender error:(nullable NSString *)error;
 - (void)pageChanged:(RNTPTDocumentView *)sender previousPageNumber:(int)previousPageNumber;
@@ -396,4 +404,12 @@ static const PTAnnotationToolbarKey PTAnnotationToolbarKeyItems = @"items";
 @interface RNTPTThumbnailsViewController : PTThumbnailsViewController
 
 @end
+
+// Custom toolbar button
+@interface PTCustomToolbarButton : PTSelectableBarButtonItem
+
+@property (nonatomic, strong) NSDictionary<NSString *, id> *toolbarData;
+
+@end
+
 NS_ASSUME_NONNULL_END

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -1857,7 +1857,7 @@ NS_ASSUME_NONNULL_END
             else if ([bottomToolbarValue isKindOfClass:[NSDictionary class]]) {
                 // Custom bottom toolbar dictionary.
                 NSDictionary<NSString *, id> *bottomToolbar = (NSDictionary *)bottomToolbarValue;
-                PTCustomToolbarButton *bottomToolbarItem = [self createCustomToolbarItemWithDictionary:bottomToolbar];
+                PTCustomToolbarButton *bottomToolbarItem = [self createCustomToolbarButtonWithDictionary:bottomToolbar];
                 [bottomToolbarItems addObject:bottomToolbarItem];
                 [bottomToolbarItems addObject:space];
             }
@@ -1929,14 +1929,14 @@ NS_ASSUME_NONNULL_END
     return toolGroup;
 }
 
-- (PTSelectableBarButtonItem *)createCustomToolbarItemWithDictionary:(NSDictionary<NSString *, id> *)dictionary
+- (PTSelectableBarButtonItem *)createCustomToolbarButtonWithDictionary:(NSDictionary<NSString *, id> *)dictionary
 {
     NSString *toolbarId = dictionary[PTCustomToolbarButonKeyId];
     NSString *toolbarName = dictionary[PTCustomToolbarButonKeyName];
     NSString *toolbarIcon = dictionary[PTCustomToolbarButonKeyIcon];
     NSString *toolbarSelected = dictionary[PTCustomToolbarButonKeySelected];
       
-    PTCustomToolbarButton* toolbarItem = [[PTCustomToolbarButton alloc] initWithImage:[UIImage systemImageNamed:toolbarIcon] style:UIBarButtonItemStylePlain target:self action:@selector(customToolbarPressed:)];
+    PTCustomToolbarButton* toolbarItem = [[PTCustomToolbarButton alloc] initWithImage:[UIImage systemImageNamed:toolbarIcon] style:UIBarButtonItemStylePlain target:self action:@selector(customToolbarButtonPressed:)];
     toolbarItem.toolbarData = dictionary;
     toolbarItem.title = toolbarName;
     
@@ -2081,10 +2081,10 @@ NS_ASSUME_NONNULL_END
     }
 }
 
-- (void)customToolbarPressed:(PTCustomToolbarButton *)sender
+- (void)customToolbarButtonPressed:(PTCustomToolbarButton *)sender
 {
-    if ([self.delegate respondsToSelector:@selector(customToolbarPressed:toolbar:)]) {
-        [self.delegate customToolbarPressed:self toolbar:sender.toolbarData];
+    if ([self.delegate respondsToSelector:@selector(customToolbarButtonPressed:toolbar:)]) {
+        [self.delegate customToolbarButtonPressed:self toolbar:sender.toolbarData];
     }
 }
 

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -1823,12 +1823,21 @@ NS_ASSUME_NONNULL_END
     
     // Handle topAppNavBarRightBar.
     if (self.topAppNavBarRightBar && self.topAppNavBarRightBar.count >= 0) {
-        
+
         NSMutableArray *righBarItems = [[NSMutableArray alloc] init];
         
-        for (NSString *rightBarItemString in self.topAppNavBarRightBar) {
-            UIBarButtonItem *rightBarItem = [self itemForButton:rightBarItemString];
-            if (rightBarItem) {
+        for (id rightBarItemValue in self.topAppNavBarRightBar) {
+            if ([rightBarItemValue isKindOfClass:[NSString class]]) {
+                // Default right bar button key.
+                UIBarButtonItem *rightBarItem = [self itemForButton:rightBarItemValue];
+                if (rightBarItem) {
+                    [righBarItems addObject:rightBarItem];
+                }
+            }
+            else if ([rightBarItemValue isKindOfClass:[NSDictionary class]]) {
+                // Custom bottom toolbar button dictionary.
+                NSDictionary<NSString *, id> *buttonData = (NSDictionary *)rightBarItemValue;
+                PTCustomToolbarButton *rightBarItem = [self createCustomToolbarButtonWithDictionary:buttonData];
                 [righBarItems addObject:rightBarItem];
             }
         }
@@ -1847,7 +1856,7 @@ NS_ASSUME_NONNULL_END
         
         for (id bottomToolbarValue in self.bottomToolbar) {
             if ([bottomToolbarValue isKindOfClass:[NSString class]]) {
-                // Default bottom toolbar key.
+                // Default bottom toolbar button key.
                 UIBarButtonItem *bottomToolbarItem = [self itemForButton:bottomToolbarValue];
                 if (bottomToolbarItem) {
                     [bottomToolbarItems addObject:bottomToolbarItem];
@@ -1855,9 +1864,9 @@ NS_ASSUME_NONNULL_END
                 }
             }
             else if ([bottomToolbarValue isKindOfClass:[NSDictionary class]]) {
-                // Custom bottom toolbar dictionary.
-                NSDictionary<NSString *, id> *bottomToolbar = (NSDictionary *)bottomToolbarValue;
-                PTCustomToolbarButton *bottomToolbarItem = [self createCustomToolbarButtonWithDictionary:bottomToolbar];
+                // Custom bottom toolbar button dictionary.
+                NSDictionary<NSString *, id> *buttonData = (NSDictionary *)bottomToolbarValue;
+                PTCustomToolbarButton *bottomToolbarItem = [self createCustomToolbarButtonWithDictionary:buttonData];
                 [bottomToolbarItems addObject:bottomToolbarItem];
                 [bottomToolbarItems addObject:space];
             }
@@ -1940,9 +1949,7 @@ NS_ASSUME_NONNULL_END
     toolbarItem.toolbarData = dictionary;
     toolbarItem.title = toolbarName;
     
-    if (toolbarSelected == (id)[NSNull null]) {
-        toolbarItem.selected = NO;
-    } else {
+    if (toolbarSelected != 0) {
         toolbarItem.selected = [toolbarSelected boolValue];
     }
     
@@ -2083,8 +2090,15 @@ NS_ASSUME_NONNULL_END
 
 - (void)customToolbarButtonPressed:(PTCustomToolbarButton *)sender
 {
+    NSDictionary<NSString *, id> *toolbar = sender.toolbarData;
+    NSString *toolbarSelected = toolbar[PTCustomToolbarButonKeySelected];
+        
+    if (toolbarSelected != 0) {
+        sender.selected = !sender.selected;
+    }
+        
     if ([self.delegate respondsToSelector:@selector(customToolbarButtonPressed:toolbar:)]) {
-        [self.delegate customToolbarButtonPressed:self toolbar:sender.toolbarData];
+        [self.delegate customToolbarButtonPressed:self toolbar:toolbar];
     }
 }
 

--- a/ios/RNTPTDocumentViewManager.m
+++ b/ios/RNTPTDocumentViewManager.m
@@ -434,11 +434,11 @@ RCT_CUSTOM_VIEW_PROPERTY(verticalScrollPos, double, RNTPTDocumentView)
     }
 }
 
-- (void)customToolbarPressed:(RNTPTDocumentView *)sender toolbar:(NSDictionary<NSString *, id> *)toolbar
+- (void)customToolbarButtonPressed:(RNTPTDocumentView *)sender toolbar:(NSDictionary<NSString *, id> *)toolbar
 {
     if (sender.onChange) {
         sender.onChange(@{
-            @"onCustomToolbarPressed": @"onCustomToolbarPressed",
+            @"onCustomToolbarButtonPressed": @"onCustomToolbarButtonPressed",
             @"toolbar": toolbar
         });
     }

--- a/ios/RNTPTDocumentViewManager.m
+++ b/ios/RNTPTDocumentViewManager.m
@@ -374,6 +374,13 @@ RCT_CUSTOM_VIEW_PROPERTY(bottomToolbar, NSArray, RNTPTDocumentView)
     }
 }
 
+RCT_CUSTOM_VIEW_PROPERTY(moreItemsToolbar, NSArray, RNTPTDocumentView)
+{
+    if (json) {
+        view.moreItemsToolbar = [RCTConvert NSArray:json];
+    }
+}
+
 RCT_CUSTOM_VIEW_PROPERTY(hideAnnotationToolbarSwitcher, BOOL, RNTPTDocumentView)
 {
     if (json) {

--- a/ios/RNTPTDocumentViewManager.m
+++ b/ios/RNTPTDocumentViewManager.m
@@ -434,6 +434,16 @@ RCT_CUSTOM_VIEW_PROPERTY(verticalScrollPos, double, RNTPTDocumentView)
     }
 }
 
+- (void)customToolbarPressed:(RNTPTDocumentView *)sender toolbar:(NSDictionary<NSString *, id> *)toolbar
+{
+    if (sender.onChange) {
+        sender.onChange(@{
+            @"onCustomToolbarPressed": @"onCustomToolbarPressed",
+            @"toolbar": toolbar
+        });
+    }
+}
+
 - (void)documentLoaded:(RNTPTDocumentView *)sender
 {
     if (sender.onChange) {

--- a/src/Config/Config.js
+++ b/src/Config/Config.js
@@ -196,6 +196,14 @@ export default {
     Items: "items"
   },
 
+  // CustomToolbarButonKey defines the necessary keys for a custom toolbar button
+  CustomToolbarButonKey: {
+    Id: "id",
+    Name: "name",
+    Icon: "icon",
+    Selected: "selected"
+  },
+
   // ThumbnailFilterMode defines filter modes in the thumbnails browser
   ThumbnailFilterMode: {
     Annotated: "annotated",

--- a/src/DocumentView/DocumentView.js
+++ b/src/DocumentView/DocumentView.js
@@ -21,6 +21,7 @@ export default class DocumentView extends PureComponent {
     leadingNavButtonIcon: PropTypes.string,
     showLeadingNavButton: PropTypes.bool,
     onLeadingNavButtonPressed: PropTypes.func,
+    onCustomToolbarButtonPressed: PropTypes.func,
     onDocumentLoaded: PropTypes.func,
     onDocumentError: PropTypes.func,
     onPageChanged: PropTypes.func,
@@ -87,6 +88,10 @@ export default class DocumentView extends PureComponent {
     if (event.nativeEvent.onLeadingNavButtonPressed) {
       if (this.props.onLeadingNavButtonPressed) {
         this.props.onLeadingNavButtonPressed();
+      }
+    } else if (event.nativeEvent.onCustomToolbarButtonPressed) {
+      if (this.props.onCustomToolbarButtonPressed) {
+        this.props.onCustomToolbarButtonPressed(event.nativeEvent.toolbar);
       }
     } else if (event.nativeEvent.onDocumentLoaded) {
       if (this.props.onDocumentLoaded) {

--- a/src/DocumentView/DocumentView.js
+++ b/src/DocumentView/DocumentView.js
@@ -73,6 +73,7 @@ export default class DocumentView extends PureComponent {
     hideDefaultAnnotationToolbars: PropTypes.array,
     topAppNavBarRightBar: PropTypes.array,
     bottomToolbar: PropTypes.array,
+    moreItemsToolbar: PropTypes.array,
     hideAnnotationToolbarSwitcher: PropTypes.bool,
     hideTopToolbars: PropTypes.bool,
     hideTopAppNavBar: PropTypes.bool,


### PR DESCRIPTION
Hello

For the project I'm working on I had to add custom toolbar buttons, so I made this branch to make it available for the public repo.

https://user-images.githubusercontent.com/9582420/113211579-08ef4380-924c-11eb-8abf-b874090e3bf4.mov

This is the code used in the video:
```jsx
<DocumentView
         bottomToolbar={[
		{
			[Config.CustomToolbarButonKey.Id]: 'test1',
			[Config.CustomToolbarButonKey.Name]: 'Test 1',
			[Config.CustomToolbarButonKey.Icon]: 'eye'
		},
		{
			[Config.CustomToolbarButonKey.Id]: 'test1Selectable',
			[Config.CustomToolbarButonKey.Name]: 'Test 1 - selectable',
			[Config.CustomToolbarButonKey.Icon]: 'eye',
			[Config.CustomToolbarButonKey.Selected]: true
		}
	]}
	topAppNavBarRightBar={[
		{
			[Config.CustomToolbarButonKey.Id]: 'test2',
			[Config.CustomToolbarButonKey.Name]: 'Test 2',
			[Config.CustomToolbarButonKey.Icon]: 'gear'
		},
		Config.Buttons.moreItemsButton,
	]}
	moreItemsToolbar={[
		Config.Buttons.shareButton,
		{
			[Config.CustomToolbarButonKey.Id]: 'test3',
			[Config.CustomToolbarButonKey.Name]: 'Test 3',
			[Config.CustomToolbarButonKey.Icon]: 'gear'
		}
	]}
	onCustomToolbarButtonPressed={toolbar => {
		console.log('Custom toolbar button pressed:', toolbar);
         }}
/>
```
The only thjing I couldn't figure out is how to handle the `onCustomToolbarButtonPressed` on moreItemsToolbar items, the sender is resolving to the MoreItems menu instead of the one of the pressed button.


Function:
moreItemsToolbar

Prop:
onCustomToolbarButtonPressed					