### PR TITLE
Support custom bottom toolbar for Android

### DIFF
--- a/API.md
+++ b/API.md
@@ -451,7 +451,7 @@ Customizes the right bar section of the top app nav bar. If passed in, the defau
 ```
 
 #### bottomToolbar
-array of strings, optional, iOS only
+array of strings, optional, only the outline list, thumbnail list, share, view mode, search, and reflow buttons are supported on Android
 
 Defines a custom bottom toolbar. If passed in, the default bottom toolbar will not be used. Strings should be [Config.Buttons](./src/Config/Config.js) constants.
 

--- a/android/src/main/java/com/pdftron/reactnative/viewmanagers/DocumentViewViewManager.java
+++ b/android/src/main/java/com/pdftron/reactnative/viewmanagers/DocumentViewViewManager.java
@@ -109,6 +109,11 @@ public class DocumentViewViewManager extends ViewGroupManager<DocumentView> {
         documentView.setBottomToolbarEnabled(bottomToolbarEnabled);
     }
 
+    @ReactProp(name = "bottomToolbar")
+    public void bottomToolbar(DocumentView documentView, @NonNull ReadableArray bottomToolbarItems) {
+        documentView.bottomToolbar(bottomToolbarItems);
+    }
+
     @ReactProp(name = "hideToolbarsOnTap")
     public void setHideToolbarsOnTap(DocumentView documentView, boolean hideToolbarsOnTap) {
         documentView.setHideToolbarsOnTap(hideToolbarsOnTap);

--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -66,6 +66,7 @@ import com.pdftron.pdf.utils.PdfDocManager;
 import com.pdftron.pdf.utils.PdfViewCtrlSettingsManager;
 import com.pdftron.pdf.utils.Utils;
 import com.pdftron.pdf.utils.ViewerUtils;
+import com.pdftron.pdf.widget.bottombar.builder.BottomBarBuilder;
 import com.pdftron.pdf.widget.toolbar.builder.AnnotationToolbarBuilder;
 import com.pdftron.pdf.widget.toolbar.builder.ToolbarButtonType;
 import com.pdftron.pdf.widget.toolbar.component.DefaultToolbars;
@@ -288,6 +289,30 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
 
     public void setBottomToolbarEnabled(boolean bottomToolbarEnabled) {
         mBuilder = mBuilder.showBottomToolbar(bottomToolbarEnabled);
+    }
+
+    public void bottomToolbar(ReadableArray bottomToolbarItems) {
+        BottomBarBuilder customBottomBar = BottomBarBuilder.withTag("CustomBottomBar");
+
+        for (int i = 0; i < bottomToolbarItems.size(); i++) {
+            String item = bottomToolbarItems.getString(i);
+
+            if (BUTTON_THUMBNAILS.equals(item)) {
+                customBottomBar.addCustomButton(R.string.pref_viewmode_thumbnails, R.drawable.ic_thumbnails_grid_black_24dp, R.id.action_thumbnails);
+            } else if (BUTTON_LISTS.equals(item)) {
+                customBottomBar.addCustomButton(R.string.action_outline, R.drawable.ic_outline_white_24dp, R.id.action_outline);
+            } else if (BUTTON_SHARE.equals(item)) {
+                customBottomBar.addCustomButton(R.string.action_file_share, R.drawable.ic_share_black_24dp, R.id.action_share);
+            } else if (BUTTON_VIEW_CONTROLS.equals(item)) {
+                customBottomBar.addCustomButton(R.string.action_view_mode, R.drawable.ic_viewing_mode_white_24dp, R.id.action_viewmode);
+            } else if (BUTTON_SEARCH.equals(item)) {
+                customBottomBar.addCustomButton(R.string.action_search, R.drawable.ic_search_white_24dp, R.id.action_search);
+            } else if (BUTTON_REFLOW.equals(item)) {
+                customBottomBar.addCustomButton(R.string.pref_viewmode_reflow, R.drawable.ic_view_mode_reflow_black_24dp, R.id.action_reflow_mode);
+            }
+        }
+
+        mBuilder.bottomBarBuilder(customBottomBar);
     }
 
     public void setDocumentSliderEnabled(boolean documentSliderEnabled) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "2.0.3-beta.81",
+  "version": "2.0.3-beta.82",
   "description": "React Native Pdftron",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Add support for customizing bottom toolbar on Android. Currently only the outline list, thumbnail list, share, view mode, search, and reflow buttons are supported

Example:
`          bottomToolbar={[Config.Buttons.reflowButton, Config.Buttons.listsButton, Config.Buttons.thumbnailsButton, Config.Buttons.shareButton, Config.Buttons.viewControlsButton,  Config.Buttons.searchButton]}
`