### PR TITLE
Expose native UI customization apis

### DIFF
--- a/API.md
+++ b/API.md
@@ -686,7 +686,7 @@ Whether to show images in reflow mode.
 ```
 
 #### reflowOrientation
-string, optional, default value is 'Horizontal'
+string, optional, default value is 'Horizontal'. Android only.
 
 Sets the scrolling direction of the reflow control. Strings should be [`Config.ReflowOrientation`](./src/Config/Config.js) constants.
 

--- a/API.md
+++ b/API.md
@@ -672,6 +672,30 @@ vertical | number | the vertical position of the scroll
   }}
 ```
 
+### Reflow
+
+#### imageInReflowEnabled
+bool, optional, defaults to true
+
+Whether to show images in reflow mode. 
+
+```js
+<DocumentView
+  imageInReflowEnabled={false}
+/>
+```
+
+#### reflowOrientation
+string, optional, default value is 'Horizontal'
+
+Sets the scrolling direction of the reflow control. Strings should be [`Config.ReflowOrientation`](./src/Config/Config.js) constants.
+
+```js
+<DocumentView
+  reflowOrientation={Config.ReflowOrientation.Vertical} 
+/>
+```
+
 ### Annotation Menu
 
 #### hideAnnotationMenu

--- a/android/src/main/java/com/pdftron/reactnative/utils/Constants.java
+++ b/android/src/main/java/com/pdftron/reactnative/utils/Constants.java
@@ -339,6 +339,10 @@ public final class Constants {
     public static final String KEY_COLOR_POST_PROCESS_MODE_GRADIENT_MAP = "gradientMap";
     public static final String KEY_COLOR_POST_PROCESS_MODE_NIGHT_MODE = "nightMode";
 
+    // ReflowOrientation
+    public static final String REFLOW_ORIENTATION_HORIZONTAL = "horizontal";
+    public static final String REFLOW_ORIENTATION_VERTICAL = "vertical";
+
     // Export format
     public static final String KEY_EXPORT_FORMAT_BMP = "BMP";
     public static final String KEY_EXPORT_FORMAT_JPG = "JPG";

--- a/android/src/main/java/com/pdftron/reactnative/utils/Constants.java
+++ b/android/src/main/java/com/pdftron/reactnative/utils/Constants.java
@@ -340,8 +340,8 @@ public final class Constants {
     public static final String KEY_COLOR_POST_PROCESS_MODE_NIGHT_MODE = "nightMode";
 
     // ReflowOrientation
-    public static final String REFLOW_ORIENTATION_HORIZONTAL = "horizontal";
-    public static final String REFLOW_ORIENTATION_VERTICAL = "vertical";
+    public static final String KEY_REFLOW_ORIENTATION_HORIZONTAL = "horizontal";
+    public static final String KEY_REFLOW_ORIENTATION_VERTICAL = "vertical";
 
     // Export format
     public static final String KEY_EXPORT_FORMAT_BMP = "BMP";

--- a/android/src/main/java/com/pdftron/reactnative/viewmanagers/DocumentViewViewManager.java
+++ b/android/src/main/java/com/pdftron/reactnative/viewmanagers/DocumentViewViewManager.java
@@ -254,6 +254,11 @@ public class DocumentViewViewManager extends ViewGroupManager<DocumentView> {
         documentView.setImageInReflowEnabled(imageInReflowEnabled);
     }
 
+    @ReactProp(name = "reflowOrientation")
+    public void setReflowOrientation(DocumentView documentView, int reflowOrientation) {
+        documentView.setReflowOrientation(reflowOrientation);
+    }
+
     @ReactProp(name = "selectAnnotationAfterCreation")
     public void setSelectAnnotationAfterCreation(DocumentView documentView, boolean selectAnnotationAfterCreation) {
         documentView.setSelectAnnotationAfterCreation(selectAnnotationAfterCreation);

--- a/android/src/main/java/com/pdftron/reactnative/viewmanagers/DocumentViewViewManager.java
+++ b/android/src/main/java/com/pdftron/reactnative/viewmanagers/DocumentViewViewManager.java
@@ -249,6 +249,11 @@ public class DocumentViewViewManager extends ViewGroupManager<DocumentView> {
         documentView.setAnnotationsListEditingEnabled(annotationsListEditingEnabled);
     }
 
+    @ReactProp(name = "imageInReflowEnabled")
+    public void setImageInReflowEnabled(DocumentView documentView, boolean imageInReflowEnabled) {
+        documentView.setImageInReflowEnabled(imageInReflowEnabled);
+    }
+
     @ReactProp(name = "selectAnnotationAfterCreation")
     public void setSelectAnnotationAfterCreation(DocumentView documentView, boolean selectAnnotationAfterCreation) {
         documentView.setSelectAnnotationAfterCreation(selectAnnotationAfterCreation);

--- a/android/src/main/java/com/pdftron/reactnative/viewmanagers/DocumentViewViewManager.java
+++ b/android/src/main/java/com/pdftron/reactnative/viewmanagers/DocumentViewViewManager.java
@@ -244,11 +244,6 @@ public class DocumentViewViewManager extends ViewGroupManager<DocumentView> {
         documentView.setThumbnailViewEditingEnabled(thumbnailViewEditingEnabled);
     }
 
-    @ReactProp(name = "annotationsListEditingEnabled")
-    public void setAnnotationsListEditingEnabled(DocumentView documentView, boolean annotationsListEditingEnabled) {
-        documentView.setAnnotationsListEditingEnabled(annotationsListEditingEnabled);
-    }
-
     @ReactProp(name = "imageInReflowEnabled")
     public void setImageInReflowEnabled(DocumentView documentView, boolean imageInReflowEnabled) {
         documentView.setImageInReflowEnabled(imageInReflowEnabled);

--- a/android/src/main/java/com/pdftron/reactnative/viewmanagers/DocumentViewViewManager.java
+++ b/android/src/main/java/com/pdftron/reactnative/viewmanagers/DocumentViewViewManager.java
@@ -255,7 +255,7 @@ public class DocumentViewViewManager extends ViewGroupManager<DocumentView> {
     }
 
     @ReactProp(name = "reflowOrientation")
-    public void setReflowOrientation(DocumentView documentView, int reflowOrientation) {
+    public void setReflowOrientation(DocumentView documentView, String reflowOrientation) {
         documentView.setReflowOrientation(reflowOrientation);
     }
 

--- a/android/src/main/java/com/pdftron/reactnative/viewmanagers/DocumentViewViewManager.java
+++ b/android/src/main/java/com/pdftron/reactnative/viewmanagers/DocumentViewViewManager.java
@@ -244,6 +244,11 @@ public class DocumentViewViewManager extends ViewGroupManager<DocumentView> {
         documentView.setThumbnailViewEditingEnabled(thumbnailViewEditingEnabled);
     }
 
+    @ReactProp(name = "annotationsListEditingEnabled")
+    public void setAnnotationsListEditingEnabled(DocumentView documentView, boolean annotationsListEditingEnabled) {
+        documentView.setAnnotationsListEditingEnabled(annotationsListEditingEnabled);
+    }
+
     @ReactProp(name = "selectAnnotationAfterCreation")
     public void setSelectAnnotationAfterCreation(DocumentView documentView, boolean selectAnnotationAfterCreation) {
         documentView.setSelectAnnotationAfterCreation(selectAnnotationAfterCreation);

--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -490,10 +490,6 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
         mBuilder = mBuilder.thumbnailViewEditingEnabled(thumbnailViewEditingEnabled);
     }
 
-    public void setAnnotationsListEditingEnabled(boolean annotationsListEditingEnabled) {
-        mBuilder = mBuilder.annotationsListEditingEnabled(annotationsListEditingEnabled);
-    }
-
     public void setImageInReflowEnabled(boolean imageInReflowEnabled) {
         mBuilder = mBuilder.imageInReflowEnabled(imageInReflowEnabled);
     }

--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -489,6 +489,10 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
         mBuilder = mBuilder.thumbnailViewEditingEnabled(thumbnailViewEditingEnabled);
     }
 
+    public void setAnnotationsListEditingEnabled(boolean annotationsListEditingEnabled) {
+        mBuilder = mBuilder.annotationsListEditingEnabled(annotationsListEditingEnabled);
+    }
+
     public void setSelectAnnotationAfterCreation(boolean selectAnnotationAfterCreation) {
         mToolManagerBuilder = mToolManagerBuilder.setAutoSelect(selectAnnotationAfterCreation);
     }

--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -493,6 +493,10 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
         mBuilder = mBuilder.annotationsListEditingEnabled(annotationsListEditingEnabled);
     }
 
+    public void setImageInReflowEnabled(boolean imageInReflowEnabled) {
+        mBuilder = mBuilder.imageInReflowEnabled(imageInReflowEnabled);
+    }
+
     public void setSelectAnnotationAfterCreation(boolean selectAnnotationAfterCreation) {
         mToolManagerBuilder = mToolManagerBuilder.setAutoSelect(selectAnnotationAfterCreation);
     }

--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -500,10 +500,9 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
 
     public void setReflowOrientation(String reflowOrientation) {
         int orientation = ReflowControl.HORIZONTAL;
-        // int annotType = Annot.e_Unknown;
-        if (REFLOW_ORIENTATION_HORIZONTAL.equals(reflowOrientation)) {
+        if (KEY_REFLOW_ORIENTATION_HORIZONTAL.equals(reflowOrientation)) {
             orientation = ReflowControl.HORIZONTAL;
-        } else if (REFLOW_ORIENTATION_VERTICAL.equals(reflowOrientation)) {
+        } else if (KEY_REFLOW_ORIENTATION_VERTICAL.equals(reflowOrientation)) {
             orientation = ReflowControl.VERTICAL;
         }
         mBuilder = mBuilder.reflowOrientation(orientation);

--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -50,6 +50,7 @@ import com.pdftron.pdf.config.ViewerConfig;
 import com.pdftron.pdf.controls.PdfViewCtrlTabFragment2;
 import com.pdftron.pdf.controls.PdfViewCtrlTabHostFragment2;
 import com.pdftron.pdf.controls.ThumbnailsViewFragment;
+import com.pdftron.pdf.controls.ReflowControl;
 import com.pdftron.pdf.dialog.ViewModePickerDialogFragment;
 import com.pdftron.pdf.dialog.digitalsignature.DigitalSignatureDialogFragment;
 import com.pdftron.pdf.model.AnnotStyle;
@@ -497,8 +498,15 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
         mBuilder = mBuilder.imageInReflowEnabled(imageInReflowEnabled);
     }
 
-    public void setReflowOrientation(int reflowOrientation) {
-        mBuilder = mBuilder.reflowOrientation(reflowOrientation);
+    public void setReflowOrientation(String reflowOrientation) {
+        int orientation = ReflowControl.HORIZONTAL;
+        // int annotType = Annot.e_Unknown;
+        if (REFLOW_ORIENTATION_HORIZONTAL.equals(reflowOrientation)) {
+            orientation = ReflowControl.HORIZONTAL;
+        } else if (REFLOW_ORIENTATION_VERTICAL.equals(reflowOrientation)) {
+            orientation = ReflowControl.VERTICAL;
+        }
+        mBuilder = mBuilder.reflowOrientation(orientation);
     }
 
     public void setSelectAnnotationAfterCreation(boolean selectAnnotationAfterCreation) {

--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -497,6 +497,10 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
         mBuilder = mBuilder.imageInReflowEnabled(imageInReflowEnabled);
     }
 
+    public void setReflowOrientation(int reflowOrientation) {
+        mBuilder = mBuilder.reflowOrientation(reflowOrientation);
+    }
+
     public void setSelectAnnotationAfterCreation(boolean selectAnnotationAfterCreation) {
         mToolManagerBuilder = mToolManagerBuilder.setAutoSelect(selectAnnotationAfterCreation);
     }

--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -496,9 +496,7 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
 
     public void setReflowOrientation(String reflowOrientation) {
         int orientation = ReflowControl.HORIZONTAL;
-        if (KEY_REFLOW_ORIENTATION_HORIZONTAL.equals(reflowOrientation)) {
-            orientation = ReflowControl.HORIZONTAL;
-        } else if (KEY_REFLOW_ORIENTATION_VERTICAL.equals(reflowOrientation)) {
+        if (KEY_REFLOW_ORIENTATION_VERTICAL.equals(reflowOrientation)) {
             orientation = ReflowControl.VERTICAL;
         }
         mBuilder = mBuilder.reflowOrientation(orientation);

--- a/ios/RNTPTDocumentView.h
+++ b/ios/RNTPTDocumentView.h
@@ -108,6 +108,9 @@ static NSString * const PTFacingContinuousLayoutModeKey = @"FacingContinuous";
 static NSString * const PTFacingCoverLayoutModeKey = @"FacingCover";
 static NSString * const PTFacingCoverContinuousLayoutModeKey = @"FacingCoverContinuous";
 
+static NSString * const PTHorizontalReflowOrientationKey = @"horizontal";
+static NSString * const PTVerticalReflowOrientationKey = @"vertical";
+
 static NSString * const PTModifyAnnotationActionKey = @"modify";
 static NSString * const PTAddAnnotationActionKey = @"add";
 static NSString * const PTDeleteAnnotationActionKey = @"delete";
@@ -340,6 +343,7 @@ static const PTAnnotationToolbarKey PTAnnotationToolbarKeyItems = @"items";
 
 @property (nonatomic, copy) NSString *fitMode;
 @property (nonatomic, copy) NSString *layoutMode;
+@property (nonatomic, copy) NSString *reflowOrientation;
 
 @property (nonatomic, copy, nullable) NSArray<NSString *> *annotationMenuItems;
 

--- a/ios/RNTPTDocumentView.h
+++ b/ios/RNTPTDocumentView.h
@@ -347,6 +347,8 @@ static const PTAnnotationToolbarKey PTAnnotationToolbarKeyItems = @"items";
 
 @property (nonatomic, assign, getter=isThumbnailViewEditingEnabled) BOOL thumbnailViewEditingEnabled;
 
+@property (nonatomic, assign) BOOL annotationsListEditingEnabled;
+
 @property (nonatomic, copy) NSString *annotationAuthor;
 
 @property (nonatomic) BOOL continuousAnnotationEditing;

--- a/ios/RNTPTDocumentView.h
+++ b/ios/RNTPTDocumentView.h
@@ -351,8 +351,6 @@ static const PTAnnotationToolbarKey PTAnnotationToolbarKeyItems = @"items";
 
 @property (nonatomic, assign, getter=isThumbnailViewEditingEnabled) BOOL thumbnailViewEditingEnabled;
 
-@property (nonatomic, assign) BOOL annotationsListEditingEnabled;
-
 @property (nonatomic, assign) BOOL imageInReflowEnabled;
 
 @property (nonatomic, copy) NSString *annotationAuthor;

--- a/ios/RNTPTDocumentView.h
+++ b/ios/RNTPTDocumentView.h
@@ -108,9 +108,6 @@ static NSString * const PTFacingContinuousLayoutModeKey = @"FacingContinuous";
 static NSString * const PTFacingCoverLayoutModeKey = @"FacingCover";
 static NSString * const PTFacingCoverContinuousLayoutModeKey = @"FacingCoverContinuous";
 
-static NSString * const PTHorizontalReflowOrientationKey = @"horizontal";
-static NSString * const PTVerticalReflowOrientationKey = @"vertical";
-
 static NSString * const PTModifyAnnotationActionKey = @"modify";
 static NSString * const PTAddAnnotationActionKey = @"add";
 static NSString * const PTDeleteAnnotationActionKey = @"delete";
@@ -343,7 +340,6 @@ static const PTAnnotationToolbarKey PTAnnotationToolbarKeyItems = @"items";
 
 @property (nonatomic, copy) NSString *fitMode;
 @property (nonatomic, copy) NSString *layoutMode;
-@property (nonatomic, copy) NSString *reflowOrientation;
 
 @property (nonatomic, copy, nullable) NSArray<NSString *> *annotationMenuItems;
 

--- a/ios/RNTPTDocumentView.h
+++ b/ios/RNTPTDocumentView.h
@@ -349,6 +349,8 @@ static const PTAnnotationToolbarKey PTAnnotationToolbarKeyItems = @"items";
 
 @property (nonatomic, assign) BOOL annotationsListEditingEnabled;
 
+@property (nonatomic, assign) BOOL imageInReflowEnabled;
+
 @property (nonatomic, copy) NSString *annotationAuthor;
 
 @property (nonatomic) BOOL continuousAnnotationEditing;

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -1753,7 +1753,6 @@ NS_ASSUME_NONNULL_END
     // Reflow orientation.
     if ([self.reflowOrientation isEqualToString:PTHorizontalReflowOrientationKey]) {
         documentViewController.reflowViewController.scrollingDirection = PTReflowViewControllerScrollingDirectionHorizontal;
-        // This works, however in order for reflow orientation to be horizontal in sample app, "View Settings" -> "Vertical Scrolling" button must be turned off.
     } else if ([self.reflowOrientation isEqualToString:PTVerticalReflowOrientationKey]) {
         documentViewController.reflowViewController.scrollingDirection = PTReflowViewControllerScrollingDirectionVertical;
     }

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -1558,13 +1558,6 @@ NS_ASSUME_NONNULL_END
     [self applyViewerSettings];
 }
 
--(void)setAnnotationsListEditingEnabled:(BOOL)annotationsListEditingEnabled
-{
-   _annotationsListEditingEnabled = annotationsListEditingEnabled;
-
-   [self applyViewerSettings];
-}
-
 -(void)setImageInReflowEnabled:(BOOL)imageInReflowEnabled
 {
    _imageInReflowEnabled = imageInReflowEnabled;
@@ -1743,9 +1736,6 @@ NS_ASSUME_NONNULL_END
     
     // Custom HTTP request headers.
     [self applyCustomHeaders:documentViewController];
-
-    // Annotations list editing enabled.
-    documentViewController.navigationListsViewController.annotationViewController.readonly = !self.annotationsListEditingEnabled;
 
     // Image in reflow mode enabled.
     documentViewController.reflowViewController.reflowMode = self.imageInReflowEnabled;

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -1744,11 +1744,19 @@ NS_ASSUME_NONNULL_END
     // Custom HTTP request headers.
     [self applyCustomHeaders:documentViewController];
 
-   // Annotations list editing enabled.
-   documentViewController.navigationListsViewController.annotationViewController.readonly = !self.annotationsListEditingEnabled;
+    // Annotations list editing enabled.
+    documentViewController.navigationListsViewController.annotationViewController.readonly = !self.annotationsListEditingEnabled;
 
-   // Image in reflow mode enabled.
-   documentViewController.reflowViewController.reflowMode = self.imageInReflowEnabled;
+    // Image in reflow mode enabled.
+    documentViewController.reflowViewController.reflowMode = self.imageInReflowEnabled;
+
+    // Reflow orientation.
+    if ([self.reflowOrientation isEqualToString:PTHorizontalReflowOrientationKey]) {
+        documentViewController.reflowViewController.scrollingDirection = PTReflowViewControllerScrollingDirectionHorizontal;
+        // This works, however in order for reflow orientation to be horizontal in sample app, "View Settings" -> "Vertical Scrolling" button must be turned off.
+    } else if ([self.reflowOrientation isEqualToString:PTVerticalReflowOrientationKey]) {
+        documentViewController.reflowViewController.scrollingDirection = PTReflowViewControllerScrollingDirectionVertical;
+    }
 }
 
 - (void)applyLeadingNavButton
@@ -3259,6 +3267,13 @@ NS_ASSUME_NONNULL_END
     if (annotation) {
         [toolManager selectAnnotation:annotation onPageNumber:(unsigned long)pageNumber];
     }
+}
+
+- (void)setReflowOrientation:(NSString *)reflowOrientation
+{
+    _reflowOrientation = reflowOrientation;
+
+    [self applyViewerSettings];
 }
 
 

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -1751,6 +1751,7 @@ NS_ASSUME_NONNULL_END
     documentViewController.reflowViewController.reflowMode = self.imageInReflowEnabled;
 
     // Reflow orientation.
+    // Currently gets overridden by "View Settings" -> "Vertical Scrolling" in sample app.
     if ([self.reflowOrientation isEqualToString:PTHorizontalReflowOrientationKey]) {
         documentViewController.reflowViewController.scrollingDirection = PTReflowViewControllerScrollingDirectionHorizontal;
     } else if ([self.reflowOrientation isEqualToString:PTVerticalReflowOrientationKey]) {

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -1565,6 +1565,13 @@ NS_ASSUME_NONNULL_END
    [self applyViewerSettings];
 }
 
+-(void)setImageInReflowEnabled:(BOOL)imageInReflowEnabled
+{
+   _imageInReflowEnabled = imageInReflowEnabled;
+
+   [self applyViewerSettings];
+}
+
 - (void)setSelectAnnotationAfterCreation:(BOOL)selectAnnotationAfterCreation
 {
     _selectAnnotationAfterCreation = selectAnnotationAfterCreation;
@@ -1739,6 +1746,9 @@ NS_ASSUME_NONNULL_END
 
    // Annotations list editing enabled.
    documentViewController.navigationListsViewController.annotationViewController.readonly = !self.annotationsListEditingEnabled;
+
+   // Image in reflow mode enabled.
+   documentViewController.reflowViewController.reflowMode = self.imageInReflowEnabled;
 }
 
 - (void)applyLeadingNavButton

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -1558,6 +1558,13 @@ NS_ASSUME_NONNULL_END
     [self applyViewerSettings];
 }
 
+-(void)setAnnotationsListEditingEnabled:(BOOL)annotationsListEditingEnabled
+{
+   _annotationsListEditingEnabled = annotationsListEditingEnabled;
+
+   [self applyViewerSettings];
+}
+
 - (void)setSelectAnnotationAfterCreation:(BOOL)selectAnnotationAfterCreation
 {
     _selectAnnotationAfterCreation = selectAnnotationAfterCreation;
@@ -1602,7 +1609,7 @@ NS_ASSUME_NONNULL_END
     // Thumbnail editing enabled.
     documentViewController.thumbnailsViewController.editingEnabled = self.thumbnailViewEditingEnabled;
     documentViewController.thumbnailsViewController.navigationController.toolbarHidden = !self.thumbnailViewEditingEnabled;
-    
+
     // Select after creation.
     toolManager.selectAnnotationAfterCreation = self.selectAnnotationAfterCreation;
     
@@ -1729,6 +1736,9 @@ NS_ASSUME_NONNULL_END
     
     // Custom HTTP request headers.
     [self applyCustomHeaders:documentViewController];
+
+   // Annotations list editing enabled.
+   documentViewController.navigationListsViewController.annotationViewController.readonly = !self.annotationsListEditingEnabled;
 }
 
 - (void)applyLeadingNavButton

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -1739,14 +1739,6 @@ NS_ASSUME_NONNULL_END
 
     // Image in reflow mode enabled.
     documentViewController.reflowViewController.reflowMode = self.imageInReflowEnabled;
-
-    // Reflow orientation.
-    // Currently gets overridden by "View Settings" -> "Vertical Scrolling" in sample app.
-    if ([self.reflowOrientation isEqualToString:PTHorizontalReflowOrientationKey]) {
-        documentViewController.reflowViewController.scrollingDirection = PTReflowViewControllerScrollingDirectionHorizontal;
-    } else if ([self.reflowOrientation isEqualToString:PTVerticalReflowOrientationKey]) {
-        documentViewController.reflowViewController.scrollingDirection = PTReflowViewControllerScrollingDirectionVertical;
-    }
 }
 
 - (void)applyLeadingNavButton
@@ -3257,13 +3249,6 @@ NS_ASSUME_NONNULL_END
     if (annotation) {
         [toolManager selectAnnotation:annotation onPageNumber:(unsigned long)pageNumber];
     }
-}
-
-- (void)setReflowOrientation:(NSString *)reflowOrientation
-{
-    _reflowOrientation = [reflowOrientation copy];
-
-    [self applyViewerSettings];
 }
 
 

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -3261,7 +3261,7 @@ NS_ASSUME_NONNULL_END
 
 - (void)setReflowOrientation:(NSString *)reflowOrientation
 {
-    _reflowOrientation = reflowOrientation;
+    _reflowOrientation = [reflowOrientation copy];
 
     [self applyViewerSettings];
 }

--- a/ios/RNTPTDocumentViewManager.m
+++ b/ios/RNTPTDocumentViewManager.m
@@ -311,13 +311,6 @@ RCT_CUSTOM_VIEW_PROPERTY(imageInReflowEnabled, BOOL, RNTPTDocumentView)
    }
 }
 
-RCT_CUSTOM_VIEW_PROPERTY(reflowOrientation, NSString, RNTPTDocumentView)
-{
-   if (json) {
-       view.reflowOrientation = [RCTConvert NSString:json];
-   }
-}
-
 RCT_CUSTOM_VIEW_PROPERTY(selectAnnotationAfterCreation, BOOL, RNTPTDocumentView)
 {
     if (json) {

--- a/ios/RNTPTDocumentViewManager.m
+++ b/ios/RNTPTDocumentViewManager.m
@@ -318,6 +318,13 @@ RCT_CUSTOM_VIEW_PROPERTY(imageInReflowEnabled, BOOL, RNTPTDocumentView)
    }
 }
 
+RCT_CUSTOM_VIEW_PROPERTY(reflowOrientation, NSString, RNTPTDocumentView)
+{
+   if (json) {
+       view.reflowOrientation = [RCTConvert NSString:json];
+   }
+}
+
 RCT_CUSTOM_VIEW_PROPERTY(selectAnnotationAfterCreation, BOOL, RNTPTDocumentView)
 {
     if (json) {

--- a/ios/RNTPTDocumentViewManager.m
+++ b/ios/RNTPTDocumentViewManager.m
@@ -311,6 +311,13 @@ RCT_CUSTOM_VIEW_PROPERTY(annotationsListEditingEnabled, BOOL, RNTPTDocumentView)
    }
 }
 
+RCT_CUSTOM_VIEW_PROPERTY(imageInReflowEnabled, BOOL, RNTPTDocumentView)
+{
+   if (json) {
+       view.imageInReflowEnabled = [RCTConvert BOOL:json];
+   }
+}
+
 RCT_CUSTOM_VIEW_PROPERTY(selectAnnotationAfterCreation, BOOL, RNTPTDocumentView)
 {
     if (json) {

--- a/ios/RNTPTDocumentViewManager.m
+++ b/ios/RNTPTDocumentViewManager.m
@@ -304,6 +304,13 @@ RCT_CUSTOM_VIEW_PROPERTY(thumbnailViewEditingEnabled, BOOL, RNTPTDocumentView)
     }
 }
 
+RCT_CUSTOM_VIEW_PROPERTY(annotationsListEditingEnabled, BOOL, RNTPTDocumentView)
+{
+   if (json) {
+       view.annotationsListEditingEnabled = [RCTConvert BOOL:json];
+   }
+}
+
 RCT_CUSTOM_VIEW_PROPERTY(selectAnnotationAfterCreation, BOOL, RNTPTDocumentView)
 {
     if (json) {

--- a/ios/RNTPTDocumentViewManager.m
+++ b/ios/RNTPTDocumentViewManager.m
@@ -304,13 +304,6 @@ RCT_CUSTOM_VIEW_PROPERTY(thumbnailViewEditingEnabled, BOOL, RNTPTDocumentView)
     }
 }
 
-RCT_CUSTOM_VIEW_PROPERTY(annotationsListEditingEnabled, BOOL, RNTPTDocumentView)
-{
-   if (json) {
-       view.annotationsListEditingEnabled = [RCTConvert BOOL:json];
-   }
-}
-
 RCT_CUSTOM_VIEW_PROPERTY(imageInReflowEnabled, BOOL, RNTPTDocumentView)
 {
    if (json) {

--- a/src/Config/Config.js
+++ b/src/Config/Config.js
@@ -239,6 +239,12 @@ export default {
     NightMode: "nightMode"
   },
 
+  // ReflowOrientation defines the scrolling direction when in reflow viewing mode
+  ReflowOrientation: {
+    Horizontal: 'horizontal',
+    Vertical: 'vertical',
+  },
+
   // Export to format
   ExportFormat: {
     BMP: "BMP",

--- a/src/DocumentView/DocumentView.js
+++ b/src/DocumentView/DocumentView.js
@@ -91,6 +91,7 @@ export default class DocumentView extends PureComponent {
     pageStackEnabled: PropTypes.bool,
     showQuickNavigationButton: PropTypes.bool,
     annotationsListEditingEnabled: PropTypes.bool,
+    imageInReflowEnabled: PropTypes.bool,
     ...ViewPropTypes,
   };
 

--- a/src/DocumentView/DocumentView.js
+++ b/src/DocumentView/DocumentView.js
@@ -92,7 +92,7 @@ export default class DocumentView extends PureComponent {
     showQuickNavigationButton: PropTypes.bool,
     annotationsListEditingEnabled: PropTypes.bool,
     imageInReflowEnabled: PropTypes.bool,
-    reflowOrientation: PropTypes.number,
+    reflowOrientation: PropTypes.string,
     ...ViewPropTypes,
   };
 

--- a/src/DocumentView/DocumentView.js
+++ b/src/DocumentView/DocumentView.js
@@ -92,6 +92,7 @@ export default class DocumentView extends PureComponent {
     showQuickNavigationButton: PropTypes.bool,
     annotationsListEditingEnabled: PropTypes.bool,
     imageInReflowEnabled: PropTypes.bool,
+    reflowOrientation: PropTypes.number,
     ...ViewPropTypes,
   };
 

--- a/src/DocumentView/DocumentView.js
+++ b/src/DocumentView/DocumentView.js
@@ -90,6 +90,7 @@ export default class DocumentView extends PureComponent {
     hideViewModeItems: PropTypes.array,
     pageStackEnabled: PropTypes.bool,
     showQuickNavigationButton: PropTypes.bool,
+    annotationsListEditingEnabled: PropTypes.bool,
     ...ViewPropTypes,
   };
 

--- a/src/DocumentView/DocumentView.js
+++ b/src/DocumentView/DocumentView.js
@@ -90,7 +90,6 @@ export default class DocumentView extends PureComponent {
     hideViewModeItems: PropTypes.array,
     pageStackEnabled: PropTypes.bool,
     showQuickNavigationButton: PropTypes.bool,
-    annotationsListEditingEnabled: PropTypes.bool,
     imageInReflowEnabled: PropTypes.bool,
     reflowOrientation: PropTypes.string,
     ...ViewPropTypes,


### PR DESCRIPTION
Implemented exposure of:
- imageInReflowEnabled (Android) and PTReflowViewController.reflowMode (iOS)
- reflowOrientation (Android) 

For each property in RN, I used the Android name.

Removed my exposures of:
- annotationsListEditingEnabled (Android) and PTAnnotationViewController.readonly (iOS)
- PTReflowViewController.scrollingDirection (iOS)