### PR TITLE
Set annotationListEditingEnabled as Android only

### DIFF
--- a/API.md
+++ b/API.md
@@ -1105,7 +1105,7 @@ fields | array | array of field data in the format `{fieldName: string, fieldVal
 ```
 
 #### annotationListEditingEnabled
-bool, optional, default value is true
+bool, optional, Android only, default value is true
 
 If document editing is enabled, then this value determines if the annotation list is editable.
 

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -1757,7 +1757,7 @@ NS_ASSUME_NONNULL_END
     [self applyCustomHeaders:documentViewController];
 
     // Set Annotation List Editing 
-    documentViewController.navigationListsViewController.annotationViewController.readonly = !self.annotationsListEditingEnabled;
+    // documentViewController.navigationListsViewController.annotationViewController.readonly = !self.annotationsListEditingEnabled;
     
     // Hanlde displays of various sizes
     documentViewController.alwaysShowNavigationListsAsModal = !self.showNavigationListAsSidePanelOnLargeDevices;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "2.0.3-beta.114",
+  "version": "2.0.3-beta.115",
   "description": "React Native Pdftron",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Due to refactoring in the PTAnnotationViewController class, the annotationListEditingEnabled prop no longer works on iOS. 

Until a solution is made, the prop should be set to as Android only.