### PR TITLE
Add annotation id to onExportAnnotationCommand

### DIFF
--- a/API.md
+++ b/API.md
@@ -931,7 +931,7 @@ Sets the limit on the maximum number of tabs that the viewer could have at a tim
 #### collabEnabled
 bool, optional, defaults to false
 
-Defines whether to enable realtime collaboration. If true then `currentUser` must be set as well for collaboration mode to work.
+Defines whether to enable realtime collaboration. If true then `currentUser` must be set as well for collaboration mode to work. Feature set may vary between local and collaboration mode
 
 ```js
 <DocumentView
@@ -1014,7 +1014,8 @@ Defines whether an annotation is selected after it is created. On iOS, this func
 #### onExportAnnotationCommand
 function, optional
 
-This function is called if a change has been made to annotations in the current document. Unlike [`onAnnotationChanged`](#onAnnotationChanged), this function has an XFDF command string as its parameter.
+This function is called if a change has been made to annotations in the current document. Unlike [`onAnnotationChanged`](#onAnnotationChanged), this function has an XFDF command string as its parameter. If you are modifying or deleting multiple annotations, then on Android the function is only called once, and on iOS it is called for each annotation.
+
 
 Parameters:
 
@@ -1022,13 +1023,26 @@ Name | Type | Description
 --- | --- | ---
 action | string | the action that occurred (add, delete, modify)
 xfdfCommand | string | an xfdf string containing info about the edit
+annotations | array | an array of annotation data. When collaboration is enabled data comes in the format `{id: string}`, otherwise the format is `{id: string, pageNumber: number, type: string}`. In both cases, the data represents the annotations that have been changed. Type is one of the [`Config.Tools`](./src/Config/Config.js) constants 
+
+**Known Issues** <br/> 
+On iOS, there is currently a bug that prevents the last XFDF from being retrieved when modifying annotations while collaboration mode is enabled.
 
 ```js
 <DocumentView
-  onExportAnnotationCommand = {({action, xfdfCommand}) => {
+  onExportAnnotationCommand = {({action, xfdfCommand, annotations}) => {
     console.log('Annotation edit action is', action);
     console.log('The exported xfdfCommand is', xfdfCommand);
+    annotations.forEach((annotation, index) => {
+      console.log('annotation ', index, ' id', annotation.id);
+      if (!this.state.collabEnabled) {
+        console.log('annotation ', index, ' pageNumber', annotation.pageNumber);
+        console.log('annotation ', index, ' type', annotation.type);
+      }
+    });
   }}
+  collabEnabled={this.state.collabEnabled}
+  currentUser={'Pdftron'}
 />
 ```
 

--- a/API.md
+++ b/API.md
@@ -1034,10 +1034,10 @@ On iOS, there is currently a bug that prevents the last XFDF from being retrieve
     console.log('Annotation edit action is', action);
     console.log('The exported xfdfCommand is', xfdfCommand);
     annotations.forEach((annotation, index) => {
-      console.log('annotation ', index, ' id', annotation.id);
+      console.log('Annotation ', index, ' id is', annotation.id);
       if (!this.state.collabEnabled) {
-        console.log('annotation ', index, ' pageNumber', annotation.pageNumber);
-        console.log('annotation ', index, ' type', annotation.type);
+        console.log('Annotation ', index, ' pageNumber is', annotation.pageNumber);
+        console.log('Annotation ', index, ' type is', annotation.type);
       }
     });
   }}

--- a/API.md
+++ b/API.md
@@ -1105,7 +1105,7 @@ fields | array | array of field data in the format `{fieldName: string, fieldVal
 ```
 
 #### annotationListEditingEnabled
-bool, optional, default value is true
+bool, optional, Android only, default value is true
 
 If document editing is enabled, then this value determines if the annotation list is editable.
 

--- a/API.md
+++ b/API.md
@@ -1033,11 +1033,11 @@ On iOS, there is currently a bug that prevents the last XFDF from being retrieve
   onExportAnnotationCommand = {({action, xfdfCommand, annotations}) => {
     console.log('Annotation edit action is', action);
     console.log('The exported xfdfCommand is', xfdfCommand);
-    annotations.forEach((annotation, index) => {
-      console.log('Annotation ', index, ' id is', annotation.id);
+    annotations.forEach((annotation) => {
+      console.log('Annotation id is', annotation.id);
       if (!this.state.collabEnabled) {
-        console.log('Annotation ', index, ' pageNumber is', annotation.pageNumber);
-        console.log('Annotation ', index, ' type is', annotation.type);
+        console.log('Annotation pageNumber is', annotation.pageNumber);
+        console.log('Annotation type is', annotation.type);
       }
     });
   }}

--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -2440,12 +2440,6 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
 
                                     WritableMap annotData = Arguments.createMap();
                                     annotData.putString(KEY_ANNOTATION_ID, uid == null ? "" : uid);
-                                    annotData.putInt(KEY_ANNOTATION_PAGE, annot.getPage());
-                                    try {
-                                        annotData.putString(KEY_ANNOTATION_TYPE, convAnnotTypeToString(annot.getType()));
-                                    } catch (Exception e) {
-                                        e.printStackTrace();
-                                    }
                                     annotList.pushMap(annotData);
                                 }
 

--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -2302,6 +2302,37 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
                 e.printStackTrace();
             }
 
+            WritableArray annotList = Arguments.createArray();
+            for (Map.Entry<Annot, Integer> entry : map.entrySet()) {
+                Annot key = entry.getKey();
+
+                String uid = null;
+                try {
+                    uid = key.getUniqueID() != null ? key.getUniqueID().getAsPDFText() : null;
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+
+                if (uid == null) {
+                    uid = UUID.randomUUID().toString();
+                    try {
+                        key.setUniqueID(uid);
+                    } catch (PDFNetException e) {
+                        e.printStackTrace();
+                    }
+                }
+
+                WritableMap annotData = Arguments.createMap();
+                annotData.putString(KEY_ANNOTATION_ID, uid == null ? "" : uid);
+                annotData.putInt(KEY_ANNOTATION_PAGE, entry.getValue());
+                try {
+                    annotData.putString(KEY_ANNOTATION_TYPE, convAnnotTypeToString(key.getType()));
+                } catch (PDFNetException e) {
+                    e.printStackTrace();
+                }
+                annotList.pushMap(annotData);
+            }
+
             WritableMap params = Arguments.createMap();
             params.putString(ON_EXPORT_ANNOTATION_COMMAND, ON_EXPORT_ANNOTATION_COMMAND);
             if (xfdfCommand == null) {
@@ -2309,6 +2340,7 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
             } else {
                 params.putString(KEY_ACTION, action);
                 params.putString(KEY_XFDF_COMMAND, xfdfCommand);
+                params.putArray(KEY_ANNOTATIONS, annotList);
             }
             onReceiveNativeEvent(params);
         }

--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -2267,6 +2267,7 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
                     key.setUniqueID(uid);
                 } catch (PDFNetException e) {
                     e.printStackTrace();
+                    uid = null;
                 }
             }
 
@@ -2319,6 +2320,7 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
                         key.setUniqueID(uid);
                     } catch (PDFNetException e) {
                         e.printStackTrace();
+                        uid = null;
                     }
                 }
 
@@ -2435,6 +2437,7 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
                                             annot.setId(uid);
                                         } catch (Exception e) {
                                             e.printStackTrace();
+                                            uid = null;
                                         }
                                     }
 

--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -2419,9 +2419,40 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
                         public void onSendAnnotation(String s, ArrayList<AnnotationEntity> arrayList, String s1, @Nullable String s2) {
                             if (mCollabManager != null) {
                                 WritableMap params = Arguments.createMap();
+
+                                WritableArray annotList = Arguments.createArray();
+                                for (AnnotationEntity annot : arrayList) {
+                                    String uid = null;
+                                    try {
+                                        uid = annot.getId();
+                                    } catch (Exception e) {
+                                        e.printStackTrace();
+                                    }
+
+                                    if (uid == null) {
+                                        uid = UUID.randomUUID().toString();
+                                        try {
+                                            annot.setId(uid);
+                                        } catch (Exception e) {
+                                            e.printStackTrace();
+                                        }
+                                    }
+
+                                    WritableMap annotData = Arguments.createMap();
+                                    annotData.putString(KEY_ANNOTATION_ID, uid == null ? "" : uid);
+                                    annotData.putInt(KEY_ANNOTATION_PAGE, annot.getPage());
+                                    try {
+                                        annotData.putString(KEY_ANNOTATION_TYPE, convAnnotTypeToString(annot.getType()));
+                                    } catch (Exception e) {
+                                        e.printStackTrace();
+                                    }
+                                    annotList.pushMap(annotData);
+                                }
+
                                 params.putString(ON_EXPORT_ANNOTATION_COMMAND, ON_EXPORT_ANNOTATION_COMMAND);
                                 params.putString(KEY_ACTION, s);
                                 params.putString(KEY_XFDF_COMMAND, mCollabManager.getLastXfdf());
+                                params.putArray(KEY_ANNOTATIONS, annotList);
                                 onReceiveNativeEvent(params);
                             }
                         }

--- a/ios/RNTPTDocumentView.h
+++ b/ios/RNTPTDocumentView.h
@@ -291,7 +291,7 @@ static const PTAnnotationToolbarKey PTAnnotationToolbarKeyItems = @"items";
 
 - (void)formFieldValueChanged:(RNTPTDocumentView *)sender fields:(NSDictionary *)fields;
 
-- (void)exportAnnotationCommand:(RNTPTDocumentView *)sender action:(NSString *)action xfdfCommand:(NSString *)xfdfCommand;
+- (void)exportAnnotationCommand:(RNTPTDocumentView *)sender action:(NSString *)action xfdfCommand:(NSString *)xfdfCommand annotation:(NSDictionary*)annotation;
 
 - (void)annotationMenuPressed:(RNTPTDocumentView *)sender annotationMenu:(NSString *)annotationMenu annotations:(NSArray<NSDictionary<NSString *, id> *> *)annotations;
 

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -2978,32 +2978,36 @@ NS_ASSUME_NONNULL_END
 
 - (void)localAnnotationAdded:(PTCollaborationAnnotation *)collaborationAnnotation
 {
-    [self rnt_sendExportAnnotationCommandWithAction:PTAddAnnotationActionKey
-                                        xfdfCommand:collaborationAnnotation.xfdf annotation:@{
-                                            PTAnnotationIdKey: collaborationAnnotation.annotationID,
-                                        }];
+    [self rnt_sendExportAnnotationCommandWithAction:PTAddAnnotationActionKey annotation:collaborationAnnotation pageNumber:-1 annotType:@""];
 }
 
 - (void)localAnnotationModified:(PTCollaborationAnnotation *)collaborationAnnotation
 {
-    [self rnt_sendExportAnnotationCommandWithAction:PTModifyAnnotationActionKey
-                                        xfdfCommand:collaborationAnnotation.xfdf annotation:@{
-                                            PTAnnotationIdKey: collaborationAnnotation.annotationID,
-                                        }];
+    [self rnt_sendExportAnnotationCommandWithAction:PTModifyAnnotationActionKey annotation:collaborationAnnotation pageNumber:-1 annotType:@""];
 }
 
 - (void)localAnnotationRemoved:(PTCollaborationAnnotation *)collaborationAnnotation
 {
-    [self rnt_sendExportAnnotationCommandWithAction:PTDeleteAnnotationActionKey
-                                        xfdfCommand:collaborationAnnotation.xfdf annotation:@{
-                                            PTAnnotationIdKey: collaborationAnnotation.annotationID,
-                                        }];
+    [self rnt_sendExportAnnotationCommandWithAction:PTDeleteAnnotationActionKey annotation:collaborationAnnotation pageNumber:-1 annotType:@""];
 }
 
-- (void)rnt_sendExportAnnotationCommandWithAction:(NSString *)action xfdfCommand:(NSString *)xfdfCommand annotation:(NSDictionary *) annotation
+- (void)rnt_sendExportAnnotationCommandWithAction:(NSString *)action annotation:(PTCollaborationAnnotation *)annot pageNumber:(int)pageNumber annotType:(NSString *)annotType
 {
+    NSDictionary * annotation;
+    if (pageNumber >= 0 && ![annotType isEqualToString:@""]) {
+        annotation = @{
+            PTAnnotationIdKey: annot.annotationID,
+            PTAnnotationPageNumberKey: @(pageNumber),
+            PTAnnotationTypeKey: annotType
+        };
+    } else {
+        annotation = @{
+            PTAnnotationIdKey: annot.annotationID,
+        };
+    }
+    
     if ([self.delegate respondsToSelector:@selector(exportAnnotationCommand:action:xfdfCommand:annotation:)]) {
-        [self.delegate exportAnnotationCommand:self action:action xfdfCommand:xfdfCommand annotation:annotation];
+        [self.delegate exportAnnotationCommand:self action:action xfdfCommand:annot.xfdf annotation:annotation];
     }
 }
 
@@ -3100,11 +3104,12 @@ NS_ASSUME_NONNULL_END
     if (!self.collaborationManager) {
         PTVectorAnnot *annots = [[PTVectorAnnot alloc] init];
         [annots add:annot];
-        [self rnt_sendExportAnnotationCommandWithAction:PTAddAnnotationActionKey xfdfCommand:[self generateXfdfCommand:annots modified:[[PTVectorAnnot alloc] init] deleted:[[PTVectorAnnot alloc] init] pdfViewCtrl:pdfViewCtrl] annotation:@{
-            PTAnnotationIdKey: annotId,
-            PTAnnotationPageNumberKey: @(pageNumber),
-            PTAnnotationTypeKey: [RNTPTDocumentView stringForAnnotType:[annot GetType]],
-        }];
+        
+        PTCollaborationAnnotation * collabAnnot = [[PTCollaborationAnnotation alloc] init];
+        [collabAnnot setAnnotationID:annotId];
+        [collabAnnot setXfdf:[self generateXfdfCommand:[[PTVectorAnnot alloc] init] modified:annots deleted:[[PTVectorAnnot alloc] init] pdfViewCtrl:pdfViewCtrl]];
+        
+        [self rnt_sendExportAnnotationCommandWithAction:PTAddAnnotationActionKey annotation:collabAnnot pageNumber:pageNumber annotType:[RNTPTDocumentView stringForAnnotType:[annot GetType]]];
     }
 }
 
@@ -3132,11 +3137,12 @@ NS_ASSUME_NONNULL_END
     if (!self.collaborationManager) {
         PTVectorAnnot *annots = [[PTVectorAnnot alloc] init];
         [annots add:annot];
-        [self rnt_sendExportAnnotationCommandWithAction:PTModifyAnnotationActionKey xfdfCommand:[self generateXfdfCommand:[[PTVectorAnnot alloc] init] modified:annots deleted:[[PTVectorAnnot alloc] init] pdfViewCtrl:pdfViewCtrl] annotation:@{
-            PTAnnotationIdKey: annotId,
-            PTAnnotationPageNumberKey: @(pageNumber),
-            PTAnnotationTypeKey: [RNTPTDocumentView stringForAnnotType:[annot GetType]],
-        }];
+        
+        PTCollaborationAnnotation * collabAnnot = [[PTCollaborationAnnotation alloc] init];
+        [collabAnnot setAnnotationID:annotId];
+        [collabAnnot setXfdf:[self generateXfdfCommand:[[PTVectorAnnot alloc] init] modified:annots deleted:[[PTVectorAnnot alloc] init] pdfViewCtrl:pdfViewCtrl]];
+        
+        [self rnt_sendExportAnnotationCommandWithAction:PTModifyAnnotationActionKey annotation:collabAnnot pageNumber:pageNumber annotType:[RNTPTDocumentView stringForAnnotType:[annot GetType]]];
     }
 }
 
@@ -3164,11 +3170,12 @@ NS_ASSUME_NONNULL_END
     if (!self.collaborationManager) {
         PTVectorAnnot *annots = [[PTVectorAnnot alloc] init];
         [annots add:annot];
-        [self rnt_sendExportAnnotationCommandWithAction:PTDeleteAnnotationActionKey xfdfCommand:[self generateXfdfCommand:[[PTVectorAnnot alloc] init] modified:[[PTVectorAnnot alloc] init] deleted:annots pdfViewCtrl:pdfViewCtrl] annotation:@{
-            PTAnnotationIdKey: annotId,
-            PTAnnotationPageNumberKey: @(pageNumber),
-            PTAnnotationTypeKey: [RNTPTDocumentView stringForAnnotType:[annot GetType]],
-        }];
+        
+        PTCollaborationAnnotation * collabAnnot = [[PTCollaborationAnnotation alloc] init];
+        [collabAnnot setAnnotationID:annotId];
+        [collabAnnot setXfdf:[self generateXfdfCommand:[[PTVectorAnnot alloc] init] modified:annots deleted:[[PTVectorAnnot alloc] init] pdfViewCtrl:pdfViewCtrl]];
+        
+        [self rnt_sendExportAnnotationCommandWithAction:PTDeleteAnnotationActionKey annotation:collabAnnot pageNumber:pageNumber annotType:[RNTPTDocumentView stringForAnnotType:[annot GetType]]];
     }
 }
 
@@ -3213,11 +3220,12 @@ NS_ASSUME_NONNULL_END
         if (!self.collaborationManager) {
             PTVectorAnnot *annots = [[PTVectorAnnot alloc] init];
             [annots add:annot];
-            [self rnt_sendExportAnnotationCommandWithAction:PTModifyAnnotationActionKey xfdfCommand:[self generateXfdfCommand:[[PTVectorAnnot alloc] init] modified:annots deleted:[[PTVectorAnnot alloc] init] pdfViewCtrl:pdfViewCtrl] annotation:@{
-                PTAnnotationIdKey: annotId,
-                PTAnnotationPageNumberKey: @(pageNumber),
-                PTAnnotationTypeKey: [RNTPTDocumentView stringForAnnotType:[annot GetType]],
-            }];
+            
+            PTCollaborationAnnotation * collabAnnot = [[PTCollaborationAnnotation alloc] init];
+            [collabAnnot setAnnotationID:annotId];
+            [collabAnnot setXfdf:[self generateXfdfCommand:[[PTVectorAnnot alloc] init] modified:annots deleted:[[PTVectorAnnot alloc] init] pdfViewCtrl:pdfViewCtrl]];
+            
+            [self rnt_sendExportAnnotationCommandWithAction:PTModifyAnnotationActionKey annotation:collabAnnot pageNumber:pageNumber annotType:[RNTPTDocumentView stringForAnnotType:[annot GetType]]];
         }
     }
 }

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -2979,25 +2979,31 @@ NS_ASSUME_NONNULL_END
 - (void)localAnnotationAdded:(PTCollaborationAnnotation *)collaborationAnnotation
 {
     [self rnt_sendExportAnnotationCommandWithAction:PTAddAnnotationActionKey
-                                        xfdfCommand:collaborationAnnotation.xfdf];
+                                        xfdfCommand:collaborationAnnotation.xfdf annotation:@{
+                                            PTAnnotationIdKey: collaborationAnnotation.annotationID,
+                                        }];
 }
 
 - (void)localAnnotationModified:(PTCollaborationAnnotation *)collaborationAnnotation
 {
     [self rnt_sendExportAnnotationCommandWithAction:PTModifyAnnotationActionKey
-                                        xfdfCommand:collaborationAnnotation.xfdf];
+                                        xfdfCommand:collaborationAnnotation.xfdf annotation:@{
+                                            PTAnnotationIdKey: collaborationAnnotation.annotationID,
+                                        }];
 }
 
 - (void)localAnnotationRemoved:(PTCollaborationAnnotation *)collaborationAnnotation
 {
     [self rnt_sendExportAnnotationCommandWithAction:PTDeleteAnnotationActionKey
-                                        xfdfCommand:collaborationAnnotation.xfdf];
+                                        xfdfCommand:collaborationAnnotation.xfdf annotation:@{
+                                            PTAnnotationIdKey: collaborationAnnotation.annotationID,
+                                        }];
 }
 
-- (void)rnt_sendExportAnnotationCommandWithAction:(NSString *)action xfdfCommand:(NSString *)xfdfCommand
+- (void)rnt_sendExportAnnotationCommandWithAction:(NSString *)action xfdfCommand:(NSString *)xfdfCommand annotation:(NSDictionary *) annotation
 {
-    if ([self.delegate respondsToSelector:@selector(exportAnnotationCommand:action:xfdfCommand:)]) {
-        [self.delegate exportAnnotationCommand:self action:action xfdfCommand:xfdfCommand];
+    if ([self.delegate respondsToSelector:@selector(exportAnnotationCommand:action:xfdfCommand:annotation:)]) {
+        [self.delegate exportAnnotationCommand:self action:action xfdfCommand:xfdfCommand annotation:annotation];
     }
 }
 
@@ -3094,7 +3100,11 @@ NS_ASSUME_NONNULL_END
     if (!self.collaborationManager) {
         PTVectorAnnot *annots = [[PTVectorAnnot alloc] init];
         [annots add:annot];
-        [self rnt_sendExportAnnotationCommandWithAction:PTAddAnnotationActionKey xfdfCommand:[self generateXfdfCommand:annots modified:[[PTVectorAnnot alloc] init] deleted:[[PTVectorAnnot alloc] init] pdfViewCtrl:pdfViewCtrl]];
+        [self rnt_sendExportAnnotationCommandWithAction:PTAddAnnotationActionKey xfdfCommand:[self generateXfdfCommand:annots modified:[[PTVectorAnnot alloc] init] deleted:[[PTVectorAnnot alloc] init] pdfViewCtrl:pdfViewCtrl] annotation:@{
+            PTAnnotationIdKey: annotId,
+            PTAnnotationPageNumberKey: @(pageNumber),
+            PTAnnotationTypeKey: [RNTPTDocumentView stringForAnnotType:[annot GetType]],
+        }];
     }
 }
 
@@ -3122,7 +3132,11 @@ NS_ASSUME_NONNULL_END
     if (!self.collaborationManager) {
         PTVectorAnnot *annots = [[PTVectorAnnot alloc] init];
         [annots add:annot];
-        [self rnt_sendExportAnnotationCommandWithAction:PTModifyAnnotationActionKey xfdfCommand:[self generateXfdfCommand:[[PTVectorAnnot alloc] init] modified:annots deleted:[[PTVectorAnnot alloc] init] pdfViewCtrl:pdfViewCtrl]];
+        [self rnt_sendExportAnnotationCommandWithAction:PTModifyAnnotationActionKey xfdfCommand:[self generateXfdfCommand:[[PTVectorAnnot alloc] init] modified:annots deleted:[[PTVectorAnnot alloc] init] pdfViewCtrl:pdfViewCtrl] annotation:@{
+            PTAnnotationIdKey: annotId,
+            PTAnnotationPageNumberKey: @(pageNumber),
+            PTAnnotationTypeKey: [RNTPTDocumentView stringForAnnotType:[annot GetType]],
+        }];
     }
 }
 
@@ -3150,7 +3164,11 @@ NS_ASSUME_NONNULL_END
     if (!self.collaborationManager) {
         PTVectorAnnot *annots = [[PTVectorAnnot alloc] init];
         [annots add:annot];
-        [self rnt_sendExportAnnotationCommandWithAction:PTDeleteAnnotationActionKey xfdfCommand:[self generateXfdfCommand:[[PTVectorAnnot alloc] init] modified:[[PTVectorAnnot alloc] init] deleted:annots pdfViewCtrl:pdfViewCtrl]];
+        [self rnt_sendExportAnnotationCommandWithAction:PTDeleteAnnotationActionKey xfdfCommand:[self generateXfdfCommand:[[PTVectorAnnot alloc] init] modified:[[PTVectorAnnot alloc] init] deleted:annots pdfViewCtrl:pdfViewCtrl] annotation:@{
+            PTAnnotationIdKey: annotId,
+            PTAnnotationPageNumberKey: @(pageNumber),
+            PTAnnotationTypeKey: [RNTPTDocumentView stringForAnnotType:[annot GetType]],
+        }];
     }
 }
 
@@ -3162,6 +3180,10 @@ NS_ASSUME_NONNULL_END
     PTDocumentBaseViewController *documentViewController = self.currentDocumentViewController;
 
     PTAnnot *annot = notification.userInfo[PTToolManagerAnnotationUserInfoKey];
+    int pageNumber = ((NSNumber *)notification.userInfo[PTToolManagerPageNumberUserInfoKey]).intValue;
+    
+    NSString *annotId = [[annot GetUniqueID] IsValid] ? [[annot GetUniqueID] GetAsPDFText] : @"";
+    
     if ([annot GetType] == e_ptWidget) {
         PTPDFViewCtrl *pdfViewCtrl = documentViewController.pdfViewCtrl;
         NSError* error;
@@ -3191,7 +3213,11 @@ NS_ASSUME_NONNULL_END
         if (!self.collaborationManager) {
             PTVectorAnnot *annots = [[PTVectorAnnot alloc] init];
             [annots add:annot];
-            [self rnt_sendExportAnnotationCommandWithAction:PTModifyAnnotationActionKey xfdfCommand:[self generateXfdfCommand:[[PTVectorAnnot alloc] init] modified:annots deleted:[[PTVectorAnnot alloc] init] pdfViewCtrl:pdfViewCtrl]];
+            [self rnt_sendExportAnnotationCommandWithAction:PTModifyAnnotationActionKey xfdfCommand:[self generateXfdfCommand:[[PTVectorAnnot alloc] init] modified:annots deleted:[[PTVectorAnnot alloc] init] pdfViewCtrl:pdfViewCtrl] annotation:@{
+                PTAnnotationIdKey: annotId,
+                PTAnnotationPageNumberKey: @(pageNumber),
+                PTAnnotationTypeKey: [RNTPTDocumentView stringForAnnotType:[annot GetType]],
+            }];
         }
     }
 }

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -1757,7 +1757,7 @@ NS_ASSUME_NONNULL_END
     [self applyCustomHeaders:documentViewController];
 
     // Set Annotation List Editing 
-    documentViewController.navigationListsViewController.annotationViewController.readonly = !self.annotationsListEditingEnabled;
+    // documentViewController.navigationListsViewController.annotationViewController.readonly = !self.annotationsListEditingEnabled;
     
     // Hanlde displays of various sizes
     documentViewController.alwaysShowNavigationListsAsModal = !self.showNavigationListAsSidePanelOnLargeDevices;

--- a/ios/RNTPTDocumentViewManager.m
+++ b/ios/RNTPTDocumentViewManager.m
@@ -597,7 +597,7 @@ RCT_CUSTOM_VIEW_PROPERTY(userBookmarksListEditingEnabled, BOOL, RNTPTDocumentVie
     }
 }
 
-- (void)exportAnnotationCommand:(RNTPTDocumentView *)sender action:(NSString *)action xfdfCommand:(NSString *)xfdfCommand
+- (void)exportAnnotationCommand:(RNTPTDocumentView *)sender action:(NSString *)action xfdfCommand:(NSString *)xfdfCommand annotation:(NSDictionary *)annotation
 {
     if (sender.onChange) {
         if (xfdfCommand) {
@@ -605,6 +605,7 @@ RCT_CUSTOM_VIEW_PROPERTY(userBookmarksListEditingEnabled, BOOL, RNTPTDocumentVie
                 @"onExportAnnotationCommand": @"onExportAnnotationCommand",
                 @"action": action,
                 @"xfdfCommand": (xfdfCommand ?: @""),
+                @"annotations": @[annotation]
             });
         } else {
             sender.onChange(@{

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "2.0.3-beta.118",
+  "version": "2.0.3-beta.119",
   "description": "React Native Pdftron",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "2.0.3-beta.114",
+  "version": "2.0.3-beta.115",
   "description": "React Native Pdftron",
   "main": "index.js",
   "scripts": {

--- a/src/DocumentView/DocumentView.js
+++ b/src/DocumentView/DocumentView.js
@@ -176,6 +176,7 @@ export default class DocumentView extends PureComponent {
         this.props.onExportAnnotationCommand({
           'action': event.nativeEvent.action,
           'xfdfCommand': event.nativeEvent.xfdfCommand,
+          'annotations': event.nativeEvent.annotations,
         });
       }
     } else if (event.nativeEvent.onAnnotationMenuPress) {


### PR DESCRIPTION
Added new parameter `annotations` to `onExportAnnotationCommand`. `annotations` is an array of changed annots with the following data:

- id
- page number (non-collab mode only)
- type (non-collab mode only)