### PR TITLE
[Support] Android exportPath & openUrlPath

### DIFF
--- a/API.md
+++ b/API.md
@@ -163,6 +163,30 @@ Example:
 />
 ```
 
+#### exportPath
+string, optional
+
+Sets the folder path for all save options, this defaults to the app cache path. Android only.
+Example:
+
+```js
+<DocumentView
+  exportPath="/data/data/com.example/cache/test"
+/>
+```
+
+#### openUrlPath
+string, optional
+
+Sets the folder path for open URL files, this defaults to the app cache path. Android only.
+Example:
+
+```js
+<DocumentView
+  openUrlPath="/data/data/com.example/cache/test"
+/>
+```
+
 #### password
 string, optional
 

--- a/API.md
+++ b/API.md
@@ -163,30 +163,6 @@ Example:
 />
 ```
 
-#### exportPath
-string, optional
-
-Sets the folder path for all save options, this defaults to the app cache path. Android only.
-Example:
-
-```js
-<DocumentView
-  exportPath="/data/data/com.example/cache/test"
-/>
-```
-
-#### openUrlPath
-string, optional
-
-Sets the folder path for open URL files, this defaults to the app cache path. Android only.
-Example:
-
-```js
-<DocumentView
-  openUrlPath="/data/data/com.example/cache/test"
-/>
-```
-
 #### password
 string, optional
 
@@ -246,6 +222,30 @@ Defines whether the viewer is read-only. If true, the UI will not allow the user
 ```js
 <DocumentView
   readOnly={true}
+/>
+```
+
+#### exportPath
+string, optional
+
+Sets the folder path for all save options, this defaults to the app cache path. Android only.
+Example:
+
+```js
+<DocumentView
+  exportPath="/data/data/com.example/cache/test"
+/>
+```
+
+#### openUrlPath
+string, optional
+
+Sets the folder path for open URL files, this defaults to the app cache path. Android only.
+Example:
+
+```js
+<DocumentView
+  openUrlPath="/data/data/com.example/cache/test"
 />
 ```
 

--- a/android/src/main/java/com/pdftron/reactnative/viewmanagers/DocumentViewViewManager.java
+++ b/android/src/main/java/com/pdftron/reactnative/viewmanagers/DocumentViewViewManager.java
@@ -379,6 +379,17 @@ public class DocumentViewViewManager extends ViewGroupManager<DocumentView> {
         documentView.setRestrictDownloadUsage(restrictDownloadUsage);
     }
 
+    @ReactProp(name = "exportPath")
+    public void setExportPath(DocumentView documentView, String exportPath){
+        documentView.setExportPath(exportPath);
+    }
+
+    @ReactProp(name = "openUrlPath")
+    public void setOpenUrlPath(DocumentView documentView, String openUrlPath){
+        documentView.setOpenUrlPath(openUrlPath);
+    }
+
+
     public void importBookmarkJson(int tag, String bookmarkJson) throws PDFNetException {
         DocumentView documentView = mDocumentViews.get(tag);
         if (documentView != null) {

--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -109,7 +109,8 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
 
     private ArrayList<ToolManager.ToolMode> mDisabledTools = new ArrayList<>();
 
-    private String mCacheDir;
+    private String mExportPath;
+    private String mOpenUrlPath;
     private int mInitialPageNumber = -1;
 
     private boolean mPadStatusBar;
@@ -180,7 +181,9 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
             FragmentManager fragmentManager = ((AppCompatActivity) reactContext.getCurrentActivity()).getSupportFragmentManager();
             setSupportFragmentManager(fragmentManager);
             mFragmentManagerSave = fragmentManager;
-            mCacheDir = currentActivity.getCacheDir().getAbsolutePath();
+            String cacheDir = currentActivity.getCacheDir().getAbsolutePath();
+            mExportPath = cacheDir;
+            mOpenUrlPath = cacheDir;
             mPDFViewCtrlConfig = PDFViewCtrlConfig.getDefaultConfig(currentActivity);
         } else {
             throw new IllegalStateException("FragmentActivity required.");
@@ -538,6 +541,14 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
 
     public void setSignSignatureFieldsWithStamps(boolean signWithStamps) {
         mSignWithStamps = signWithStamps;
+    }
+
+    public void setExportPath(String exportPath){
+        mExportPath = exportPath;
+    }
+
+    public void setOpenUrlPath(String openUrlPath){
+        mOpenUrlPath = openUrlPath;
     }
 
     public void setAnnotationPermissionCheckEnabled(boolean annotPermissionCheckEnabled) {
@@ -1597,10 +1608,13 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
     }
 
     private ViewerConfig getConfig() {
-        if (mCacheDir != null) {
-            mBuilder.openUrlCachePath(mCacheDir)
-                    .saveCopyExportPath(mCacheDir);
+        if (mExportPath != null) {
+            mBuilder.saveCopyExportPath(mExportPath);
         }
+        if(mOpenUrlPath != null){
+            mBuilder.openUrlCachePath(mOpenUrlPath);
+        }
+
         if (mDisabledTools.size() > 0) {
             ToolManager.ToolMode[] modes = mDisabledTools.toArray(new ToolManager.ToolMode[0]);
             if (modes.length > 0) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "2.0.3-beta.126",
+  "version": "2.0.3-beta.127",
   "description": "React Native Pdftron",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- Added two new properties exportPath and openUrlPath for Android
- Removed mCacheDir from Document.java and replaced it with mExportPath and mOpenUrlPath, these default to the cached Directory
- Updated API.md with information on the two new properties