### PR TITLE
(iOS) fix delegate respondsToSelector check

### DIFF
--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -2668,7 +2668,7 @@ NS_ASSUME_NONNULL_END
     double horizontal = [pdfViewCtrl GetHScrollPos];
     double vertical = [pdfViewCtrl GetVScrollPos];
     
-    if ([self.delegate respondsToSelector:@selector(zoomChanged:zoom:)]) {
+    if ([self.delegate respondsToSelector:@selector(scrollChanged:horizontal:vertical:)]) {
         [self.delegate scrollChanged:self horizontal:horizontal vertical:vertical];
     }
 }
@@ -2690,7 +2690,7 @@ NS_ASSUME_NONNULL_END
     
     const double zoom = pdfViewCtrl.zoom * pdfViewCtrl.zoomScale;
     
-    if ([self.delegate respondsToSelector:@selector(zoomChanged:zoom:)]) {
+    if ([self.delegate respondsToSelector:@selector(zoomFinished:zoom:)]) {
         [self.delegate zoomFinished:self zoom:zoom];
     }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "2.0.3-beta.132",
+  "version": "2.0.3-beta.133",
   "description": "React Native Pdftron",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
When document view controller scrolls or finishes zoom, check that the delegate responds to the correct method it's about to call.