### PR TITLE
[Support] Android hide conversion progress dialog

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -55,7 +55,7 @@ repositories {
 dependencies {
     implementation "com.facebook.react:react-native:+"
 
-    implementation "com.pdftron:pdftron:9.0.2-beta09"
-    implementation "com.pdftron:tools:9.0.2-beta09"
-    implementation "com.pdftron:collab:9.0.2-beta09"
+    implementation "com.pdftron:pdftron:9.0.2-beta10"
+    implementation "com.pdftron:tools:9.0.2-beta10"
+    implementation "com.pdftron:collab:9.0.2-beta10"
 }

--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -203,6 +203,7 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
                 .maximumTabCount(Integer.MAX_VALUE)
                 .showCloseTabOption(false)
                 .useSupportActionBar(false)
+                .showConversionDialog(false)
                 .skipReadOnlyCheck(true);
     }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "2.0.3-beta.133",
+  "version": "2.0.3-beta.134",
   "description": "React Native Pdftron",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- Added showConversionDialog(false) to setup function in DocumentView
- Updated PDFTron dependencies to - com.pdftron:pdftron:9.0.2-beta10
- Updated Library version