### PR TITLE
autoResizeFreeTextEnabled, photoPickerEnabled for signatures

### DIFF
--- a/API.md
+++ b/API.md
@@ -1208,7 +1208,7 @@ Defines whether user can modify the document using the thumbnail view (eg add/re
 />
 ```
 
-### TextSelection
+### Text Selection
 
 #### onTextSearchStart
 function, optional

--- a/API.md
+++ b/API.md
@@ -1126,6 +1126,17 @@ Defines whether to show saved signatures for re-use when using the signing tool.
 />
 ```
 
+### photoPickerEnabled
+bool, optional, defaults to true
+
+Defines whether to show the option to pick images in the signature dialog.
+
+```js
+<DocumentView
+  photoPickerEnabled={true}
+/>
+```
+
 ### Thumbnail Browser
 
 #### hideThumbnailFilterModes
@@ -1228,6 +1239,17 @@ Defines whether document is automatically saved by the viewer.
 ```js
 <DocumentView
   autoSaveEnabled={true}
+/>
+```
+
+### autoResizeFreeTextEnabled
+bool, optional defaults to false
+
+Defines whether to automatically resize free text when editing
+
+```js
+<DocumentView
+  autoResizeFreeTextEnabled={true}
 />
 ```
 

--- a/API.md
+++ b/API.md
@@ -1174,7 +1174,7 @@ Defines whether to show saved signatures for re-use when using the signing tool.
 ```
 
 #### photoPickerEnabled
-bool, optional, defaults to true
+bool, optional, defaults to true. Android only.
 
 Defines whether to show the option to pick images in the signature dialog.
 
@@ -1290,9 +1290,9 @@ Defines whether document is automatically saved by the viewer.
 ```
 
 #### autoResizeFreeTextEnabled
-bool, optional defaults to false
+bool, optional, defaults to false
 
-Defines whether to automatically resize free text when editing
+Defines whether to automatically resize the bounding box of free text annotations when editing.
 
 ```js
 <DocumentView

--- a/API.md
+++ b/API.md
@@ -1173,7 +1173,7 @@ Defines whether to show saved signatures for re-use when using the signing tool.
 />
 ```
 
-### photoPickerEnabled
+#### photoPickerEnabled
 bool, optional, defaults to true
 
 Defines whether to show the option to pick images in the signature dialog.
@@ -1289,7 +1289,7 @@ Defines whether document is automatically saved by the viewer.
 />
 ```
 
-### autoResizeFreeTextEnabled
+#### autoResizeFreeTextEnabled
 bool, optional defaults to false
 
 Defines whether to automatically resize free text when editing
@@ -1300,7 +1300,6 @@ Defines whether to automatically resize free text when editing
 />
 ```
 
-#### Example:
 #### restrictDownloadUsage
 bool, optional, defaults to false
 

--- a/android/src/main/java/com/pdftron/reactnative/viewmanagers/DocumentViewViewManager.java
+++ b/android/src/main/java/com/pdftron/reactnative/viewmanagers/DocumentViewViewManager.java
@@ -357,6 +357,8 @@ public class DocumentViewViewManager extends ViewGroupManager<DocumentView> {
     @ReactProp(name = "autoResizeFreeTextEnabled")
     public void setAutoResizeFreeTextEnabled(DocumentView documentView, boolean autoResizeFreeTextEnabled) {
         documentView.setAutoResizeFreeTextEnabled(autoResizeFreeTextEnabled);
+    } 
+    
     @ReactProp(name = "annotationsListEditingEnabled")
     public void setAnnotationsListEditingEnabled(DocumentView documentView, boolean annotationsListEditingEnabled) {
         documentView.setAnnotationsListEditingEnabled(annotationsListEditingEnabled);

--- a/android/src/main/java/com/pdftron/reactnative/viewmanagers/DocumentViewViewManager.java
+++ b/android/src/main/java/com/pdftron/reactnative/viewmanagers/DocumentViewViewManager.java
@@ -339,6 +339,16 @@ public class DocumentViewViewManager extends ViewGroupManager<DocumentView> {
         documentView.setShowQuickNavigationButton(showQuickNavigationButton);
     }
 
+    @ReactProp(name = "photoPickerEnabled") 
+    public void setPhotoPickerEnabled(DocumentView documentView, boolean photoPickerEnabled) {
+        documentView.setPhotoPickerEnabled(photoPickerEnabled);
+    }
+
+    @ReactProp(name = "autoResizeFreeTextEnabled")
+    public void setAutoResizeFreeTextEnabled(DocumentView documentView, boolean autoResizeFreeTextEnabled) {
+        documentView.setAutoResizeFreeTextEnabled(autoResizeFreeTextEnabled);
+    }
+
     public void importBookmarkJson(int tag, String bookmarkJson) throws PDFNetException {
         DocumentView documentView = mDocumentViews.get(tag);
         if (documentView != null) {

--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -787,6 +787,8 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
 
     public void setAutoResizeFreeTextEnabled(boolean autoResizeFreeTextEnabled) {
         mToolManagerBuilder = mToolManagerBuilder.setAutoResizeFreeText(autoResizeFreeTextEnabled);
+    }
+    
     public void setShowNavigationListAsSidePanelOnLargeDevices(boolean showNavigationListAsSidePanelOnLargeDevices) {
         mBuilder = mBuilder.navigationListAsSheetOnLargeDevice(showNavigationListAsSidePanelOnLargeDevices);
     }

--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -750,6 +750,14 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
         mBuilder = mBuilder.showQuickNavigationButton(showQuickNavigationButton);
     }
 
+    public void setPhotoPickerEnabled(boolean photoPickerEnabled) {
+        mToolManagerBuilder = mToolManagerBuilder.setShowSignatureFromImage(photoPickerEnabled);
+    }
+
+    public void setAutoResizeFreeTextEnabled(boolean autoResizeFreeTextEnabled) {
+        mToolManagerBuilder = mToolManagerBuilder.setAutoResizeFreeText(autoResizeFreeTextEnabled);
+    }
+
     private void disableElements(ReadableArray args) {
         for (int i = 0; i < args.size(); i++) {
             String item = args.getString(i);

--- a/ios/RNTPTDocumentView.h
+++ b/ios/RNTPTDocumentView.h
@@ -366,6 +366,7 @@ static const PTAnnotationToolbarKey PTAnnotationToolbarKeyItems = @"items";
 @property (nonatomic, copy, nullable) NSString *currentUserName;
 
 @property (nonatomic, assign) BOOL selectAnnotationAfterCreation;
+@property (nonatomic, assign) BOOL autoResizeFreeTextEnabled;
 
 @property (nonatomic, strong, nullable) PTCollaborationManager *collaborationManager;
 
@@ -379,6 +380,7 @@ static const PTAnnotationToolbarKey PTAnnotationToolbarKeyItems = @"items";
 
 @property (nonatomic, assign) BOOL signSignatureFieldsWithStamps;
 
+@property (nonatomic, assign) BOOL annotationAuthorCheckEnabled;
 @property (nonatomic, assign) BOOL annotationPermissionCheckEnabled;
 
 @property (nonatomic, assign, getter=isMultiTabEnabled) BOOL multiTabEnabled;

--- a/ios/RNTPTDocumentView.h
+++ b/ios/RNTPTDocumentView.h
@@ -384,7 +384,6 @@ static const PTAnnotationToolbarKey PTAnnotationToolbarKeyItems = @"items";
 
 @property (nonatomic, assign) BOOL signSignatureFieldsWithStamps;
 
-@property (nonatomic, assign) BOOL annotationAuthorCheckEnabled;
 @property (nonatomic, assign) BOOL annotationPermissionCheckEnabled;
 
 @property (nonatomic, assign, getter=isMultiTabEnabled) BOOL multiTabEnabled;

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -1355,13 +1355,6 @@ NS_ASSUME_NONNULL_END
     return [[fieldMap allKeys] count] == 0 ? nil : fieldMap;
 }
 
--(void)setAnnotationAuthorCheckEnabled:(BOOL)annotationAuthorCheckEnabled
-{
-    _annotationAuthorCheckEnabled = annotationAuthorCheckEnabled;
-
-    [self applyViewerSettings];
-}
-
 -(void)setAnnotationPermissionCheckEnabled:(BOOL)annotationPermissionCheckEnabled
 {
     _annotationPermissionCheckEnabled = annotationPermissionCheckEnabled;
@@ -1692,9 +1685,6 @@ NS_ASSUME_NONNULL_END
     
     // Annotation author.
     toolManager.annotationAuthor = self.annotationAuthor;
-    
-    // Annotation author check enabled.
-    toolManager.annotationAuthorCheckEnabled = self.annotationAuthorCheckEnabled;
     
     // Shows saved signatures.
     toolManager.showDefaultSignature = self.showSavedSignatures;

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -71,6 +71,7 @@ NS_ASSUME_NONNULL_END
     _pageChangeOnTap = NO;
     _thumbnailViewEditingEnabled = YES;
     _selectAnnotationAfterCreation = YES;
+    _autoResizeFreeTextEnabled = YES;
     
     _followSystemDarkMode = YES;
 
@@ -1354,6 +1355,13 @@ NS_ASSUME_NONNULL_END
     return [[fieldMap allKeys] count] == 0 ? nil : fieldMap;
 }
 
+-(void)setAnnotationAuthorCheckEnabled:(BOOL)annotationAuthorCheckEnabled
+{
+    _annotationAuthorCheckEnabled = annotationAuthorCheckEnabled;
+
+    [self applyViewerSettings];
+}
+
 -(void)setAnnotationPermissionCheckEnabled:(BOOL)annotationPermissionCheckEnabled
 {
     _annotationPermissionCheckEnabled = annotationPermissionCheckEnabled;
@@ -1573,6 +1581,13 @@ NS_ASSUME_NONNULL_END
     [self applyViewerSettings];
 }
 
+- (void)setAutoResizeFreeTextEnabled:(BOOL)autoResizeFreeTextEnabled
+{
+    _autoResizeFreeTextEnabled = autoResizeFreeTextEnabled;
+    
+    [self applyViewerSettings];
+}
+
 -(void)setHideAnnotMenuTools:(NSArray<NSString *> *)hideAnnotMenuTools
 {
     _hideAnnotMenuTools = hideAnnotMenuTools;
@@ -1613,6 +1628,9 @@ NS_ASSUME_NONNULL_END
     
     // Select after creation.
     toolManager.selectAnnotationAfterCreation = self.selectAnnotationAfterCreation;
+    
+    // Auto resize free text enabled.
+    toolManager.autoResizeFreeTextEnabled = self.autoResizeFreeTextEnabled;
     
     // Sticky note pop up.
     toolManager.textAnnotationOptions.opensPopupOnTap = ![self.overrideBehavior containsObject:PTStickyNoteShowPopUpKey];
@@ -1667,6 +1685,9 @@ NS_ASSUME_NONNULL_END
     
     // Annotation author.
     toolManager.annotationAuthor = self.annotationAuthor;
+    
+    // Annotation author check enabled.
+    toolManager.annotationAuthorCheckEnabled = self.annotationAuthorCheckEnabled;
     
     // Shows saved signatures.
     toolManager.showDefaultSignature = self.showSavedSignatures;

--- a/ios/RNTPTDocumentViewManager.m
+++ b/ios/RNTPTDocumentViewManager.m
@@ -311,6 +311,13 @@ RCT_CUSTOM_VIEW_PROPERTY(selectAnnotationAfterCreation, BOOL, RNTPTDocumentView)
     }
 }
 
+RCT_CUSTOM_VIEW_PROPERTY(autoResizeFreeTextEnabled, BOOL, RNTPTDocumentView)
+{
+    if (json) {
+        view.autoResizeFreeTextEnabled = [RCTConvert BOOL:json];
+    }
+}
+
 RCT_CUSTOM_VIEW_PROPERTY(overrideAnnotationMenuBehavior, NSArray, RNTPTDocumentView)
 {
     if (json) {
@@ -350,6 +357,13 @@ RCT_CUSTOM_VIEW_PROPERTY(longPressMenuEnabled, BOOL, RNTPTDocumentView)
 {
     if (json) {
         view.longPressMenuEnabled = [RCTConvert BOOL:json];
+    }
+}
+
+RCT_CUSTOM_VIEW_PROPERTY(annotationAuthorCheckEnabled, BOOL, RNTPTDocumentView)
+{
+    if (json) {
+        view.annotationAuthorCheckEnabled = [RCTConvert BOOL:json];
     }
 }
 

--- a/ios/RNTPTDocumentViewManager.m
+++ b/ios/RNTPTDocumentViewManager.m
@@ -367,13 +367,6 @@ RCT_CUSTOM_VIEW_PROPERTY(longPressMenuEnabled, BOOL, RNTPTDocumentView)
     }
 }
 
-RCT_CUSTOM_VIEW_PROPERTY(annotationAuthorCheckEnabled, BOOL, RNTPTDocumentView)
-{
-    if (json) {
-        view.annotationAuthorCheckEnabled = [RCTConvert BOOL:json];
-    }
-}
-
 RCT_CUSTOM_VIEW_PROPERTY(annotationPermissionCheckEnabled, BOOL, RNTPTDocumentView)
 {
     if (json) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "2.0.3-beta.115",
+  "version": "2.0.3-beta.135",
   "description": "React Native Pdftron",
   "main": "index.js",
   "scripts": {

--- a/src/DocumentView/DocumentView.js
+++ b/src/DocumentView/DocumentView.js
@@ -90,6 +90,8 @@ export default class DocumentView extends PureComponent {
     hideViewModeItems: PropTypes.array,
     pageStackEnabled: PropTypes.bool,
     showQuickNavigationButton: PropTypes.bool,
+    photoPickerEnabled: PropTypes.bool,
+    autoResizeFreeTextEnabled: PropTypes.bool,
     ...ViewPropTypes,
   };
 


### PR DESCRIPTION
Exposed the following APIs:
- photoPickerEnabled (Android only; whether to show the option to pick images in the signature dialog)
- autoResizeFreeTextEnabled (iOS and Android)