### PR TITLE
Expose disableEditingByAnnotationType

### DIFF
--- a/API.md
+++ b/API.md
@@ -1213,6 +1213,17 @@ If document editing is enabled, then this value determines if the annotation lis
 />
 ```
 
+#### disableEditingByAnnotationType
+array of [`Config.Tools`](./src/Config/Config.js) constants, optional, defaults to none.
+
+Defines annotation types that cannot be edited after creation.
+
+```js
+<DocumentView
+  disableEditingByAnnotationType={[Config.Tools.annotationCreateTextSquiggly, Config.Tools.annotationCreateEllipse]}
+/>
+```
+
 ### Bookmark
 
 #### onBookmarkChanged

--- a/android/src/main/java/com/pdftron/reactnative/viewmanagers/DocumentViewViewManager.java
+++ b/android/src/main/java/com/pdftron/reactnative/viewmanagers/DocumentViewViewManager.java
@@ -400,6 +400,11 @@ public class DocumentViewViewManager extends ViewGroupManager<DocumentView> {
         documentView.setInkMultiStrokeEnabled(inkMultiStrokeEnabled);
     }
 
+    @ReactProp(name = "disableEditingByAnnotationType")
+    public void setDisableEditingByAnnotationType(DocumentView documentView, ReadableArray annotationTypes) {
+        documentView.setDisableEditingByAnnotationType(annotationTypes);
+    }
+
     public void importBookmarkJson(int tag, String bookmarkJson) throws PDFNetException {
         DocumentView documentView = mDocumentViews.get(tag);
         if (documentView != null) {

--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -424,6 +424,18 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
         }
     }
 
+    public void setDisableEditingByAnnotationType(ReadableArray annotationTypes) {
+        int[] annotTypes = new int[annotationTypes.size()];
+        for (int i = 0; i < annotationTypes.size(); i++) {
+            String item = annotationTypes.getString(i);
+            annotTypes[i] = convStringToAnnotType(item);
+        }
+
+        if (annotTypes.length > 0) {
+            mToolManagerBuilder = mToolManagerBuilder.disableAnnotEditing(annotTypes);
+        }
+    }
+
     public void setAnnotationAuthor(String author) {
         Context context = getContext();
         if (context != null && !Utils.isNullOrEmpty(author)) {

--- a/ios/RNTPTDocumentView.h
+++ b/ios/RNTPTDocumentView.h
@@ -312,6 +312,7 @@ static const PTAnnotationToolbarKey PTAnnotationToolbarKeyItems = @"items";
 
 @property (nonatomic, copy, nullable) NSArray<NSString *> *disabledElements;
 @property (nonatomic, copy, nullable) NSArray<NSString *> *disabledTools;
+@property (nonatomic, copy, nullable) NSArray<NSString *> *uneditableAnnotationTypes;
 
 
 // annotation selection menu customization

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -901,6 +901,32 @@ NS_ASSUME_NONNULL_END
     return NO;
 }
 
+#pragma mark - Uneditable annotation types
+
+- (void)setUneditableAnnotationTypes:(NSArray<NSString *> *)uneditableAnnotationTypes
+{
+    _uneditableAnnotationTypes = [uneditableAnnotationTypes copy];
+    
+    if (self.currentDocumentViewController) {
+        [self setAnnotationEditingPermission:uneditableAnnotationTypes toValue:NO documentViewController:self.currentDocumentViewController];
+    }
+}
+
+- (void)setAnnotationEditingPermission:(NSArray<NSString *> *)stringsArray toValue:(BOOL)value documentViewController:(PTDocumentBaseViewController *)documentViewController
+{
+    PTToolManager *toolManager = documentViewController.toolManager;
+    
+    for (NSObject *item in stringsArray) {
+        if ([item isKindOfClass:[NSString class]]) {
+            NSString *string = (NSString *)item;
+            PTExtendedAnnotType typeToSetPermission = [self reactAnnotationNameToAnnotType:string];
+            
+            // Disable text highlight annotation editing.
+            [toolManager annotationOptionsForAnnotType:typeToSetPermission].canEdit = value;
+        }
+    }
+}
+
 - (void)setPageNumber:(int)pageNumber
 {
     if (_pageNumber == pageNumber) {
@@ -1763,6 +1789,9 @@ NS_ASSUME_NONNULL_END
     
     // Disable tools.
     [self setToolsPermission:self.disabledTools toValue:NO documentViewController:documentViewController];
+    
+    // Disable editing by annotation type.
+    [self setAnnotationEditingPermission:self.uneditableAnnotationTypes toValue:NO documentViewController:documentViewController];
     
     if ([documentViewController isKindOfClass:[PTDocumentController class]]) {
         PTDocumentController *documentController = (PTDocumentController *)documentViewController;

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -921,7 +921,6 @@ NS_ASSUME_NONNULL_END
             NSString *string = (NSString *)item;
             PTExtendedAnnotType typeToSetPermission = [self reactAnnotationNameToAnnotType:string];
             
-            // Disable text highlight annotation editing.
             [toolManager annotationOptionsForAnnotType:typeToSetPermission].canEdit = value;
         }
     }

--- a/ios/RNTPTDocumentViewManager.m
+++ b/ios/RNTPTDocumentViewManager.m
@@ -493,6 +493,14 @@ RCT_CUSTOM_VIEW_PROPERTY(userBookmarksListEditingEnabled, BOOL, RNTPTDocumentVie
     }
 }
 
+RCT_CUSTOM_VIEW_PROPERTY(disableEditingByAnnotationType, NSArray, RNTPTDocumentView)
+{
+    if (json) {
+        NSArray *uneditableAnnotationTypes = [RCTConvert NSArray:json];
+        view.uneditableAnnotationTypes = uneditableAnnotationTypes;
+    }
+}
+
 - (UIView *)view
 {
     RNTPTDocumentView *documentView = [[RNTPTDocumentView alloc] init];

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "2.0.3-beta.161",
+  "version": "2.0.3-beta.162",
   "description": "React Native Pdftron",
   "main": "index.js",
   "scripts": {

--- a/src/DocumentView/DocumentView.js
+++ b/src/DocumentView/DocumentView.js
@@ -103,6 +103,7 @@ export default class DocumentView extends PureComponent {
     defaultEraserType: PropTypes.string,
     exportPath: PropTypes.string,
     openUrlPath: PropTypes.string,
+    disableEditingByAnnotationType: PropTypes.array,
     ...ViewPropTypes,
   };
 


### PR DESCRIPTION
Exposed `disableEditingByAnnotationType` prop for iOS and Android. This prop takes [Config.Tool](https://github.com/PDFTron/pdftron-react-native/blob/test-add-an-api/src/Config/Config.js) constants and defines annotation types that cannot be edited after creation.