### PR TITLE
Expose openAnnotationList

### DIFF
--- a/API.md
+++ b/API.md
@@ -2216,6 +2216,15 @@ this._viewer.getField('someFieldName').then((field) => {
 });
 ```
 
+#### openAnnotationList
+Displays the annotation tab of the existing list container. If this tab has been disabled, the method does nothing.
+
+Returns a Promise.
+
+```js
+this._viewer.openAnnotationList();
+```
+
 ### Navigation
 
 #### handleBackButton

--- a/android/src/main/java/com/pdftron/reactnative/modules/DocumentViewModule.java
+++ b/android/src/main/java/com/pdftron/reactnative/modules/DocumentViewModule.java
@@ -306,6 +306,20 @@ public class DocumentViewModule extends ReactContextBaseJavaModule implements Ac
     }
 
     @ReactMethod
+    public void openAnnotationList(final int tag, final Promise promise) {
+        getReactApplicationContext().runOnUiQueueThread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    mDocumentViewInstance.openAnnotationList(tag);
+                } catch (Exception ex) {
+                    promise.reject(ex);
+                }
+            }
+        });
+    }
+
+    @ReactMethod
     public void getCustomDataForAnnotation(final int tag, final String annotationID, final int pageNumber, final String key, final Promise promise) {
         getReactApplicationContext().runOnUiQueueThread(new Runnable() {
             @Override

--- a/android/src/main/java/com/pdftron/reactnative/viewmanagers/DocumentViewViewManager.java
+++ b/android/src/main/java/com/pdftron/reactnative/viewmanagers/DocumentViewViewManager.java
@@ -562,6 +562,15 @@ public class DocumentViewViewManager extends ViewGroupManager<DocumentView> {
         }
     }
 
+    public void openAnnotationList(int tag) throws PDFNetException
+    {
+        DocumentView documentView = mDocumentViews.get(tag);
+        if (documentView != null) {
+            documentView.openAnnotationList();
+        } else {
+            throw new PDFNetException("", 0L, getName(), "openAnnotationList", "Unable to find DocumentView.");
+        }
+    }
     public String getCustomDataForAnnotation(int tag, String annotationID, int pageNumber, String key) throws PDFNetException {
         DocumentView documentView = mDocumentViews.get(tag);
         if (documentView != null) {

--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -14,6 +14,7 @@ import android.view.ViewTreeObserver;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.FragmentManager;
 
 import com.facebook.react.bridge.Arguments;
@@ -48,10 +49,15 @@ import com.pdftron.pdf.config.PDFViewCtrlConfig;
 import com.pdftron.pdf.config.ToolConfig;
 import com.pdftron.pdf.config.ToolManagerBuilder;
 import com.pdftron.pdf.config.ViewerConfig;
+import com.pdftron.pdf.controls.AnnotationDialogFragment;
+import com.pdftron.pdf.controls.BookmarksTabLayout;
+import com.pdftron.pdf.controls.OutlineDialogFragment;
 import com.pdftron.pdf.controls.PdfViewCtrlTabFragment2;
 import com.pdftron.pdf.controls.PdfViewCtrlTabHostFragment2;
 import com.pdftron.pdf.controls.ThumbnailsViewFragment;
 import com.pdftron.pdf.controls.ReflowControl;
+import com.pdftron.pdf.controls.UserBookmarkDialogFragment;
+import com.pdftron.pdf.dialog.BookmarksDialogFragment;
 import com.pdftron.pdf.dialog.ViewModePickerDialogFragment;
 import com.pdftron.pdf.dialog.digitalsignature.DigitalSignatureDialogFragment;
 import com.pdftron.pdf.model.AnnotStyle;
@@ -67,6 +73,7 @@ import com.pdftron.pdf.utils.ActionUtils;
 import com.pdftron.pdf.utils.AnnotUtils;
 import com.pdftron.pdf.utils.BookmarkManager;
 import com.pdftron.pdf.utils.CommonToast;
+import com.pdftron.pdf.utils.DialogFragmentTab;
 import com.pdftron.pdf.utils.PdfDocManager;
 import com.pdftron.pdf.utils.PdfViewCtrlSettingsManager;
 import com.pdftron.pdf.utils.Utils;
@@ -121,6 +128,8 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
 
     private boolean mUseStylusAsPen = true;
     private boolean mSignWithStamps;
+
+    private boolean[] mListsVisible = {true, true, true};
 
     // collab
     private CollabManager mCollabManager;
@@ -841,6 +850,9 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
                         .showAnnotationsList(false)
                         .showOutlineList(false)
                         .showUserBookmarksList(false);
+                mListsVisible[0] = false;
+                mListsVisible[1] = false;
+                mListsVisible[2] = false;
             } else if (BUTTON_THUMBNAIL_SLIDER.equals(item)) {
                 mBuilder = mBuilder.showBottomNavBar(false);
             } else if (BUTTON_VIEW_LAYERS.equals(item)) {
@@ -869,10 +881,13 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
                         .showReflowOption(false);
             } else if (BUTTON_OUTLINE_LIST.equals(item)) {
                 mBuilder = mBuilder.showOutlineList(false);
+                mListsVisible[1] = false;
             } else if (BUTTON_ANNOTATION_LIST.equals(item)) {
                 mBuilder = mBuilder.showAnnotationsList(false);
+                mListsVisible[2] = false;
             } else if (BUTTON_USER_BOOKMARK_LIST.equals(item)) {
                 mBuilder = mBuilder.showUserBookmarksList(false);
+                mListsVisible[0] = false;
             } else if (BUTTON_REFLOW.equals(item)) {
                 mBuilder = mBuilder.showReflowOption(false);
                 mViewModePickerItems.add(ViewModePickerDialogFragment.ViewModePickerItems.ITEM_ID_REFLOW);
@@ -2875,6 +2890,30 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
         }
 
         return annotations;
+    }
+
+    public void openAnnotationList() {
+        if (mListsVisible[0]) {
+            if (mListsVisible[1]) {
+                if (mListsVisible[2]) {
+                    mPdfViewCtrlTabHostFragment.onOutlineOptionSelected(2);
+                }
+            } else {
+                if (mListsVisible[2]) {
+                    mPdfViewCtrlTabHostFragment.onOutlineOptionSelected(1);
+                }
+            }
+        } else {
+            if (mListsVisible[1]) {
+                if (mListsVisible[2]) {
+                    mPdfViewCtrlTabHostFragment.onOutlineOptionSelected(1);
+                } 
+            } else {
+                if (mListsVisible[2]) {
+                    mPdfViewCtrlTabHostFragment.onOutlineOptionSelected(0);
+                }
+            }
+        }
     }
 
     public String getCustomDataForAnnotation(String annotationID, int pageNumber, String key) throws PDFNetException {

--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -129,7 +129,9 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
     private boolean mUseStylusAsPen = true;
     private boolean mSignWithStamps;
 
-    private boolean[] mListsVisible = {true, true, true};
+    public boolean isBookmarkListVisible = true;
+    public boolean isOutlineListVisible = true;
+    public boolean isAnnotationListVisible = true;
 
     // collab
     private CollabManager mCollabManager;
@@ -850,9 +852,9 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
                         .showAnnotationsList(false)
                         .showOutlineList(false)
                         .showUserBookmarksList(false);
-                mListsVisible[0] = false;
-                mListsVisible[1] = false;
-                mListsVisible[2] = false;
+                isBookmarkListVisible = false;
+                isOutlineListVisible = false;
+                isAnnotationListVisible = false;
             } else if (BUTTON_THUMBNAIL_SLIDER.equals(item)) {
                 mBuilder = mBuilder.showBottomNavBar(false);
             } else if (BUTTON_VIEW_LAYERS.equals(item)) {
@@ -881,13 +883,13 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
                         .showReflowOption(false);
             } else if (BUTTON_OUTLINE_LIST.equals(item)) {
                 mBuilder = mBuilder.showOutlineList(false);
-                mListsVisible[1] = false;
+                isOutlineListVisible = false;
             } else if (BUTTON_ANNOTATION_LIST.equals(item)) {
                 mBuilder = mBuilder.showAnnotationsList(false);
-                mListsVisible[2] = false;
+                isAnnotationListVisible = false;
             } else if (BUTTON_USER_BOOKMARK_LIST.equals(item)) {
                 mBuilder = mBuilder.showUserBookmarksList(false);
-                mListsVisible[0] = false;
+                isBookmarkListVisible = false;
             } else if (BUTTON_REFLOW.equals(item)) {
                 mBuilder = mBuilder.showReflowOption(false);
                 mViewModePickerItems.add(ViewModePickerDialogFragment.ViewModePickerItems.ITEM_ID_REFLOW);
@@ -2893,23 +2895,23 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
     }
 
     public void openAnnotationList() {
-        if (mListsVisible[0]) {
-            if (mListsVisible[1]) {
-                if (mListsVisible[2]) {
+        if (isBookmarkListVisible) {
+            if (isOutlineListVisible) {
+                if (isAnnotationListVisible) {
                     mPdfViewCtrlTabHostFragment.onOutlineOptionSelected(2);
                 }
             } else {
-                if (mListsVisible[2]) {
+                if (isAnnotationListVisible) {
                     mPdfViewCtrlTabHostFragment.onOutlineOptionSelected(1);
                 }
             }
         } else {
-            if (mListsVisible[1]) {
-                if (mListsVisible[2]) {
+            if (isOutlineListVisible) {
+                if (isAnnotationListVisible) {
                     mPdfViewCtrlTabHostFragment.onOutlineOptionSelected(1);
                 } 
             } else {
-                if (mListsVisible[2]) {
+                if (isAnnotationListVisible) {
                     mPdfViewCtrlTabHostFragment.onOutlineOptionSelected(0);
                 }
             }

--- a/ios/RNTPTDocumentView.h
+++ b/ios/RNTPTDocumentView.h
@@ -570,6 +570,8 @@ static const PTAnnotationToolbarKey PTAnnotationToolbarKeyItems = @"items";
 
 - (void)setCurrentToolbar:(NSString *)toolbarTitle;
 
+- (void)openAnnotationList;
+
 @end
 
 

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -4724,6 +4724,8 @@ NS_ASSUME_NONNULL_END
 
 -(void)openAnnotationList
 {
+    if (self.documentViewController.annotationListHidden) return;
+        
     PTNavigationListsViewController *navigationListsViewController = self.documentViewController.navigationListsViewController;
     
     navigationListsViewController.selectedViewController = navigationListsViewController.annotationViewController;

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -129,7 +129,7 @@ NS_ASSUME_NONNULL_END
     }
 }
 
-#pragma mark - Document Openining
+#pragma mark - Document Opening
 
 - (void)openDocument
 {
@@ -4713,11 +4713,24 @@ NS_ASSUME_NONNULL_END
 
 #pragma mark - Online Settings
 
--(void)setRestictDownloadUsage:(BOOL)restrictDownloadUsage
+-(void)setRestrictDownloadUsage:(BOOL)restrictDownloadUsage
 {
     _restrictDownloadUsage = restrictDownloadUsage;
     
     [self applyViewerSettings];
+}
+
+#pragma mark - Open annotation list
+
+-(void)openAnnotationList
+{
+    PTNavigationListsViewController *navigationListsViewController = self.documentViewController.navigationListsViewController;
+    
+    navigationListsViewController.selectedViewController = navigationListsViewController.annotationViewController;
+    
+    UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:self.documentViewController.navigationListsViewController];
+    
+    [self.documentViewController presentViewController:navigationController animated:YES completion:nil];
 }
 
 @end

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -4724,15 +4724,12 @@ NS_ASSUME_NONNULL_END
 
 -(void)openAnnotationList
 {
-    if (self.documentViewController.annotationListHidden) return;
+    if (!self.documentViewController.annotationListHidden) {
+        PTNavigationListsViewController *navigationListsViewController = self.documentViewController.navigationListsViewController;
+        navigationListsViewController.selectedViewController = navigationListsViewController.annotationViewController;
         
-    PTNavigationListsViewController *navigationListsViewController = self.documentViewController.navigationListsViewController;
-    
-    navigationListsViewController.selectedViewController = navigationListsViewController.annotationViewController;
-    
-    UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:self.documentViewController.navigationListsViewController];
-    
-    [self.documentViewController presentViewController:navigationController animated:YES completion:nil];
+        [self.documentViewController presentViewController:navigationListsViewController animated:YES completion:nil];
+    }
 }
 
 @end

--- a/ios/RNTPTDocumentViewManager.h
+++ b/ios/RNTPTDocumentViewManager.h
@@ -156,4 +156,6 @@
 
 - (void)setCurrentToolbarForDocumentViewTag:(NSNumber *)tag toolbarTitle:(NSString*)toolbarTitle;
 
+- (void)openAnnotationListForDocumentViewTag:(NSNumber *)tag;
+
 @end

--- a/ios/RNTPTDocumentViewManager.m
+++ b/ios/RNTPTDocumentViewManager.m
@@ -884,7 +884,7 @@ RCT_CUSTOM_VIEW_PROPERTY(userBookmarksListEditingEnabled, BOOL, RNTPTDocumentVie
     if (documentView) {
         return [documentView getField:fieldName];
     } else {
-        @throw [NSException exceptionWithName:NSInvalidArgumentException reason:@"Unable to get field for tag" userInfo:nil];
+        @throw [NSException exceptionWithName:NSInvalidArgumentException reason:@"Unable to find DocumentView for tag" userInfo:nil];
         return nil;
     }
 }
@@ -1480,6 +1480,16 @@ RCT_CUSTOM_VIEW_PROPERTY(userBookmarksListEditingEnabled, BOOL, RNTPTDocumentVie
     RNTPTDocumentView *documentView = self.documentViews[tag];
     if (documentView) {
         [documentView selectAll];
+    } else {
+        @throw [NSException exceptionWithName:NSInvalidArgumentException reason:@"Unable to find DocumentView for tag" userInfo:nil];
+    }
+}
+
+- (void)openAnnotationListForDocumentViewTag:(NSNumber *)tag
+{
+    RNTPTDocumentView *documentView = self.documentViews[tag];
+    if (documentView) {
+        [documentView openAnnotationList];
     } else {
         @throw [NSException exceptionWithName:NSInvalidArgumentException reason:@"Unable to find DocumentView for tag" userInfo:nil];
     }

--- a/ios/RNTPTDocumentViewModule.m
+++ b/ios/RNTPTDocumentViewModule.m
@@ -260,7 +260,21 @@ RCT_REMAP_METHOD(getField,
         resolve(field);
     }
     @catch (NSException *exception) {
-        reject(@"set_value_for_fields", @"Failed to set value on fields", [self errorFromException:exception]);
+        reject(@"get_field", @"Failed to get field", [self errorFromException:exception]);
+    }
+}
+
+RCT_REMAP_METHOD(openAnnotationList,
+                 openAnnotationListForDocumentViewTag:(nonnull NSNumber *)tag
+                 resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject)
+{
+    @try {
+        [[self documentViewManager] openAnnotationListForDocumentViewTag:tag];
+        resolve(nil);
+    }
+    @catch (NSException *exception) {
+        reject(@"open_annotation_list", @"Failed to open annotation list", [self errorFromException:exception]);
     }
 }
 

--- a/src/DocumentView/DocumentView.js
+++ b/src/DocumentView/DocumentView.js
@@ -349,6 +349,14 @@ export default class DocumentView extends PureComponent {
     return Promise.resolve();
   }
 
+  openAnnotationList = () => {
+    const tag = findNodeHandle(this._viewerRef);
+    if(tag != null) {
+      return DocumentViewManager.openAnnotationList(tag);
+    }
+    return Promise.resolve();
+  }
+
   /**
   * note: this function exists for supporting the old version. It simply calls setValuesForFields.
   * 


### PR DESCRIPTION
Exposed `openAnnotationList` method for iOS and Android.

This method programmatically opens the annotation list. If the annotation list has been disabled, the method does nothing.