### PR TITLE
Add option to disable DigitalSignature in overflow menu

### DIFF
--- a/android/src/main/java/com/pdftron/reactnative/utils/Constants.java
+++ b/android/src/main/java/com/pdftron/reactnative/utils/Constants.java
@@ -33,6 +33,7 @@ public final class Constants {
     public static final String BUTTON_THUMBNAIL_SLIDER = "thumbnailSlider";
     public static final String BUTTON_SAVE_COPY = "saveCopyButton";
     public static final String BUTTON_EDIT_PAGES = "editPagesButton";
+    public static final String BUTTON_DIGITAL_SIGNATURE = "digitalSignatureButton";
     public static final String BUTTON_VIEW_LAYERS = "viewLayersButton";
     public static final String BUTTON_PRINT = "printButton";
     public static final String BUTTON_CLOSE = "closeButton";

--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -847,6 +847,8 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
                 mBuilder = mBuilder.showViewLayersToolbarOption(false);
             } else if (BUTTON_EDIT_PAGES.equals(item)) {
                 mBuilder = mBuilder.showEditPagesOption(false);
+            } else if (BUTTON_DIGITAL_SIGNATURE.equals(item)) {
+                mBuilder = mBuilder.showDigitalSignaturesOption(false);
             } else if (BUTTON_PRINT.equals(item)) {
                 mBuilder = mBuilder.showPrintOption(false);
             } else if (BUTTON_CLOSE.equals(item)) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "2.0.3-beta.136",
+  "version": "2.0.3-beta.137",
   "description": "React Native Pdftron",
   "main": "index.js",
   "scripts": {

--- a/src/Config/Config.js
+++ b/src/Config/Config.js
@@ -32,6 +32,7 @@ export default {
     formToolsButton: 'formToolsButton',
     fillSignToolsButton: 'fillSignToolsButton',
     moreItemsButton: 'moreItemsButton',
+    digitalSignatureButton: 'digitalSignatureButton',
     thumbnailsButton: 'thumbnailsButton',
     listsButton: 'listsButton',
     thumbnailSlider: 'thumbnailSlider',


### PR DESCRIPTION
Add option to disable DigitalSignature in overflow menu

## Support Ticket
https://support.pdftron.com/a/tickets/23262

## Issues Closed or Referenced

## Description of Changes
- add a new config (digitalSignatureButton) to disable digital signature in overflow menu

## Screenshots
