### PR TITLE
showRotate

### DIFF
--- a/API.md
+++ b/API.md
@@ -1744,6 +1744,17 @@ Returns a Promise.
 this._viewer.rotateCounterClockwise();
 ```
 
+#### showRotate
+Displays a rotate dialog. Android only.
+
+The dialog allows users to rotate pages of the opened document by 90, 180 and 270 degrees. It also displays a thumbnail of the current page at the selected rotation angle.
+
+Returns a Promise.
+
+```js
+this._viewer.showRotate();
+```
+
 ### Import/Export Annotations
 
 #### importAnnotationCommand

--- a/API.md
+++ b/API.md
@@ -1802,7 +1802,7 @@ Returns a Promise.
 this._viewer.rotateCounterClockwise();
 ```
 
-#### showRotate
+#### showRotateDialog
 Displays a rotate dialog. Android only.
 
 The dialog allows users to rotate pages of the opened document by 90, 180 and 270 degrees. It also displays a thumbnail of the current page at the selected rotation angle.
@@ -1810,7 +1810,7 @@ The dialog allows users to rotate pages of the opened document by 90, 180 and 27
 Returns a Promise.
 
 ```js
-this._viewer.showRotate();
+this._viewer.showRotateDialog();
 ```
 
 ### Import/Export Annotations

--- a/android/src/main/java/com/pdftron/reactnative/modules/DocumentViewModule.java
+++ b/android/src/main/java/com/pdftron/reactnative/modules/DocumentViewModule.java
@@ -1219,12 +1219,12 @@ public class DocumentViewModule extends ReactContextBaseJavaModule implements Ac
     }
 
     @ReactMethod
-    public void showRotate(final int tag, final Promise promise) {
+    public void showRotateDialog(final int tag, final Promise promise) {
         getReactApplicationContext().runOnUiQueueThread(new Runnable() {
             @Override
             public void run() {
                 try {
-                    mDocumentViewInstance.showRotate(tag);
+                    mDocumentViewInstance.showRotateDialog(tag);
                     promise.resolve(null);
                 } catch (Exception ex) {
                     promise.reject(ex);

--- a/android/src/main/java/com/pdftron/reactnative/modules/DocumentViewModule.java
+++ b/android/src/main/java/com/pdftron/reactnative/modules/DocumentViewModule.java
@@ -1142,6 +1142,21 @@ public class DocumentViewModule extends ReactContextBaseJavaModule implements Ac
     }
 
     @ReactMethod
+    public void showRotate(final int tag, final Promise promise) {
+        getReactApplicationContext().runOnUiQueueThread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    mDocumentViewInstance.showRotate(tag);
+                    promise.resolve(null);
+                } catch (Exception ex) {
+                    promise.reject(ex);
+                }
+            }
+        });
+    }
+
+    @ReactMethod
     public void showGoToPageView(final int tag, final Promise promise) {
         getReactApplicationContext().runOnUiQueueThread(new Runnable() {
             @Override

--- a/android/src/main/java/com/pdftron/reactnative/viewmanagers/DocumentViewViewManager.java
+++ b/android/src/main/java/com/pdftron/reactnative/viewmanagers/DocumentViewViewManager.java
@@ -1083,6 +1083,15 @@ public class DocumentViewViewManager extends ViewGroupManager<DocumentView> {
         }
     }
 
+    public void showRotate(int tag) throws PDFNetException {
+        DocumentView documentView = mDocumentViews.get(tag);
+        if (documentView != null) {
+            documentView.showRotate();
+        } else {
+            throw new PDFNetException("", 0L, getName(), "showRotate", "Unable to find DocumentView.");
+        }
+    }
+
     public void showGoToPageView(int tag) throws PDFNetException {
         DocumentView documentView = mDocumentViews.get(tag);
         if (documentView != null) {

--- a/android/src/main/java/com/pdftron/reactnative/viewmanagers/DocumentViewViewManager.java
+++ b/android/src/main/java/com/pdftron/reactnative/viewmanagers/DocumentViewViewManager.java
@@ -1147,12 +1147,12 @@ public class DocumentViewViewManager extends ViewGroupManager<DocumentView> {
         }
     }
 
-    public void showRotate(int tag) throws PDFNetException {
+    public void showRotateDialog(int tag) throws PDFNetException {
         DocumentView documentView = mDocumentViews.get(tag);
         if (documentView != null) {
-            documentView.showRotate();
+            documentView.showRotateDialog();
         } else {
-            throw new PDFNetException("", 0L, getName(), "showRotate", "Unable to find DocumentView.");
+            throw new PDFNetException("", 0L, getName(), "showRotateDialog", "Unable to find DocumentView.");
         }
     }
 

--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -52,6 +52,7 @@ import com.pdftron.pdf.controls.PdfViewCtrlTabFragment2;
 import com.pdftron.pdf.controls.PdfViewCtrlTabHostFragment2;
 import com.pdftron.pdf.controls.ThumbnailsViewFragment;
 import com.pdftron.pdf.controls.ReflowControl;
+import com.pdftron.pdf.dialog.RotateDialogFragment;
 import com.pdftron.pdf.dialog.ViewModePickerDialogFragment;
 import com.pdftron.pdf.dialog.digitalsignature.DigitalSignatureDialogFragment;
 import com.pdftron.pdf.model.AnnotStyle;
@@ -3896,6 +3897,15 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
             mPdfViewCtrlTabHostFragment.onViewModeSelected(
                     PdfViewCtrlSettingsManager.KEY_PREF_VIEWMODE_USERCROP_VALUE
             );
+        }
+    }
+
+    public void showRotate() {
+        PDFViewCtrl pdfViewCtrl = getPdfViewCtrl();
+        if (pdfViewCtrl != null && mFragmentManager != null) {
+            RotateDialogFragment.newInstance()
+                    .setPdfViewCtrl(pdfViewCtrl)
+                    .show(mFragmentManager, "rotate_dialog");
         }
     }
 

--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -4011,7 +4011,7 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
         }
     }
 
-    public void showRotate() {
+    public void showRotateDialog() {
         PDFViewCtrl pdfViewCtrl = getPdfViewCtrl();
         if (pdfViewCtrl != null && mFragmentManager != null) {
             RotateDialogFragment.newInstance()

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "2.0.3-beta.171",
+  "version": "2.0.3-beta.172",
   "description": "React Native Pdftron",
   "main": "index.js",
   "scripts": {

--- a/src/DocumentView/DocumentView.js
+++ b/src/DocumentView/DocumentView.js
@@ -903,7 +903,7 @@ export default class DocumentView extends PureComponent {
     return Promise.resolve();
   }
 
-  showRotate = () => {
+  showRotateDialog = () => {
     const tag = findNodeHandle(this._viewerRef);
     if (tag != null) {
        return DocumentViewManager.showRotate(tag);

--- a/src/DocumentView/DocumentView.js
+++ b/src/DocumentView/DocumentView.js
@@ -874,6 +874,14 @@ export default class DocumentView extends PureComponent {
     return Promise.resolve();
   }
 
+  showRotate = () => {
+    const tag = findNodeHandle(this._viewerRef);
+    if (tag != null) {
+       return DocumentViewManager.showRotate(tag);
+    }
+    return Promise.resolve();
+  }
+
   _setNativeRef = (ref) => {
     this._viewerRef = ref;
   };

--- a/src/DocumentView/DocumentView.js
+++ b/src/DocumentView/DocumentView.js
@@ -906,7 +906,7 @@ export default class DocumentView extends PureComponent {
   showRotateDialog = () => {
     const tag = findNodeHandle(this._viewerRef);
     if (tag != null) {
-       return DocumentViewManager.showRotate(tag);
+       return DocumentViewManager.showRotateDialog(tag);
     }
     return Promise.resolve();
   }


### PR DESCRIPTION
Exposed `showRotate` method. Android only.

This method opens a rotate dialog which allows user to rotate pages of the document.