### PR TITLE
[Support] Add openSavedCopyInNewTab prop

### DIFF
--- a/API.md
+++ b/API.md
@@ -272,6 +272,18 @@ Example:
 />
 ```
 
+#### openSavedCopyInNewTab
+bool, optional, default to true, Android only.
+
+Sets whether the new saved file should open after saving.
+Example:
+
+```js
+<DocumentView
+  openSavedCopyInNewTab={false}
+/>
+```
+
 #### onDocumentLoaded
 function, optional
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -55,7 +55,7 @@ repositories {
 dependencies {
     implementation "com.facebook.react:react-native:+"
 
-    implementation "com.pdftron:pdftron:9.0.2-beta10"
-    implementation "com.pdftron:tools:9.0.2-beta10"
-    implementation "com.pdftron:collab:9.0.2-beta10"
+    implementation "com.pdftron:pdftron:9.0.2-beta12"
+    implementation "com.pdftron:tools:9.0.2-beta12"
+    implementation "com.pdftron:collab:9.0.2-beta12"
 }

--- a/android/src/main/java/com/pdftron/reactnative/viewmanagers/DocumentViewViewManager.java
+++ b/android/src/main/java/com/pdftron/reactnative/viewmanagers/DocumentViewViewManager.java
@@ -415,6 +415,11 @@ public class DocumentViewViewManager extends ViewGroupManager<DocumentView> {
         documentView.setSaveStateEnabled(saveState);
     }
 
+    @ReactProp(name = "openSavedCopyInNewTab")
+    public void setOpenSavedCopyInNewTab(DocumentView documentView, boolean openSavedCopyInNewTab) {
+        documentView.setOpenSavedCopyInNewTab(openSavedCopyInNewTab);
+    }
+
     public void importBookmarkJson(int tag, String bookmarkJson) throws PDFNetException {
         DocumentView documentView = mDocumentViews.get(tag);
         if (documentView != null) {

--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -3958,6 +3958,10 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
         mSaveStateEnabled = saveStateEnabled;
     }
 
+    public void setOpenSavedCopyInNewTab(boolean openSavedCopyInNewTab) {
+        mBuilder = mBuilder.openSavedCopyInNewTab(openSavedCopyInNewTab);
+    }
+
     public ToolManager getToolManager() {
         if (getPdfViewCtrlTabFragment() != null) {
             return getPdfViewCtrlTabFragment().getToolManager();

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "2.0.3-beta.139",
+  "version": "2.0.3-beta.140",
   "description": "React Native Pdftron",
   "main": "index.js",
   "scripts": {

--- a/src/DocumentView/DocumentView.js
+++ b/src/DocumentView/DocumentView.js
@@ -106,6 +106,7 @@ export default class DocumentView extends PureComponent {
     exportPath: PropTypes.string,
     openUrlPath: PropTypes.string,
     saveStateEnabled: PropTypes.bool,
+    openSavedCopyInNewTab: PropTypes.bool,
     ...ViewPropTypes,
   };
 


### PR DESCRIPTION
Add openSavedCopyInNewTab prop

## Support Ticket
https://support.pdftron.com/a/tickets/23200

## Issues Closed or Referenced

## Description of Changes
- add a new prop (openSavedCopyInNewTab) to not open the saved file in a new tab

## Screenshots
