### PR TITLE
[Droid] Issue SDK Support 23214, dont send event on empty array

### DIFF
--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -2180,7 +2180,7 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
                     ex.printStackTrace();
                 }
             }
-            if (fieldsArray.size > 0) {
+            if (fieldsArray.size() > 0) {
                 params.putArray(KEY_FIELDS, fieldsArray);
                 onReceiveNativeEvent(params);
             }

--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -2080,8 +2080,10 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
                     ex.printStackTrace();
                 }
             }
-            params.putArray(KEY_FIELDS, fieldsArray);
-            onReceiveNativeEvent(params);
+            if (fieldsArray.size > 0) {
+                params.putArray(KEY_FIELDS, fieldsArray);
+                onReceiveNativeEvent(params);
+            }
         }
 
         @Override

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "2.0.3-beta.107",
+  "version": "2.0.3-beta.141",
   "description": "React Native Pdftron",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Support Ticket:
https://support.pdftron.com/a/tickets/23214

Do array size check when publishing event so we don't over send non-necessary events