### PR TITLE
(iOS) Replace rect with screenRect, pageRect

### DIFF
--- a/API.md
+++ b/API.md
@@ -95,7 +95,7 @@ RNPdftron.clearRubberStampCache().then(() => {
 ```
 
 ### encryptDocument
-Encrypts (password-protect) a document. **Note**: This function does not lock the document it cannot be used it while the document is opened in the viewer.
+Encrypts (password-protect) a document (must be a PDF). **Note**: This function does not lock the document it cannot be used it while the document is opened in the viewer.
 
 Parameters:
 
@@ -512,7 +512,7 @@ Defines whether to show the toolbar switcher in the top toolbar.
 #### initialToolbar
 string, optional, defaults to none
 
-Defines which [`annotationToolbar`](#annotationToolbars) should be selected when the document is opened.
+Defines which [`annotationToolbar`](#annotationToolbars) should be selected when the document is opened. The values give should be one of the [`Config.DefaultToolbars`](./src/Config/Config.js) constants or the `id` of a custom toolbar object.
 
 ```js
 <DocumentView
@@ -565,13 +565,13 @@ Customizes the right bar section of the top app nav bar. If passed in, the defau
 ```
 
 #### bottomToolbar
-array of strings, optional, only the outline list, thumbnail list, share, view mode, search, and reflow buttons are supported on Android
+array of strings, optional, only the navigation list, share, view mode, search, and reflow buttons are supported on Android
 
 Defines a custom bottom toolbar. If passed in, the default bottom toolbar will not be used. Strings should be [`Config.Buttons`](./src/Config/Config.js) constants.
 
 ```js
 <Documentview
-  bottomToolbar={[Config.Buttons.reflowButton, Config.Buttons.outlineListButton]}
+  bottomToolbar={[Config.Buttons.reflowButton, Config.Buttons.listsButton]}
 />
 ```
 

--- a/API.md
+++ b/API.md
@@ -862,7 +862,7 @@ Parameters:
 Name | Type | Description
 --- | --- | ---
 annotationMenu | string | One of [`Config.AnnotationMenu`](./src/Config/Config.js) constants, representing which item has been pressed
-annotations | array | An array of `{id: string, pageNumber: number, type: string, rect: object}` objects, where `id` is the annotation identifier, `pageNumber` is the page number, type is one of the [`Config.Tools`](./src/Config/Config.js) constants and `rect={x1, y1, x2, y2}` specifies the annotation's screen rect
+annotations | array | An array of `{id: string, pageNumber: number, type: string, screenRect: object, pageRect: object}` objects.<br><br>`id` is the annotation identifier and `type` is one of the [`Config.Tools`](./src/Config/Config.js) constants. `screenRect` was formerly called `rect`. Both rects are represented with `{x1: number, y1: number, x2: number, y2: number, width: number, height: number}` objects.
 
 ```js
 <DocumentView
@@ -872,7 +872,8 @@ annotations | array | An array of `{id: string, pageNumber: number, type: string
       console.log('The id of selected annotation is', annotation.id);
       console.log('The page number of selected annotation is', annotation.pageNumber);
       console.log('The type of selected annotation is', annotation.type);
-      console.log('The lower left corner of selected annotation is', annotation.x1, annotation.y1);
+      console.log('The screenRect of selected annotation is', annotation.screenRect);
+      console.log('The pageRect of selected annotation is', annotation.pageRect);
     });
   }}
 />
@@ -966,7 +967,7 @@ Data param table:
 Action | Data param
 --- | ---
 [`Config.Actions.linkPress`](./src/Config/Config.js) | `{url: string}`
-[`Config.Actions.stickyNoteShowPopUp`](./src/Config/Config.js) | `{id: string, pageNumber: number, type: string, rect: {x1: number, y1: number, x2: number, y2: number}}`
+[`Config.Actions.stickyNoteShowPopUp`](./src/Config/Config.js) | `{id: string, pageNumber: number, type: string, screenRect: {x1: number, y1: number, x2: number, y2: number, width: number, height: number}, pageRect: {x1: number, y1: number, x2: number, y2: number, width: number, height: number}}`. Type is one of the [`Config.Tools`](./src/Config/Config.js) constants. `screenRect` was formerly called `rect`.
 
 ```js
 <DocumentView
@@ -1158,7 +1159,7 @@ Parameters:
 
 Name | Type | Description
 --- | --- | ---
-annotations | array | array of annotation data in the format `{id: string, pageNumber: number, type: string, rect: {x1: number, y1: number, x2: number, y2: number}}`, representing the selected annotations. Type is one of the [`Config.Tools`](./src/Config/Config.js) constants
+annotations | array | array of annotation data in the format `{id: string, pageNumber: number, type: string, screenRect: {x1: number, y1: number, x2: number, y2: number, width: number, height: number}, pageRect: {x1: number, y1: number, x2: number, y2: number, width: number, height: number}}`, representing the selected annotations. Type is one of the [`Config.Tools`](./src/Config/Config.js) constants. `screenRect` was formerly called `rect`.
 
 ```js
 <DocumentView
@@ -1167,7 +1168,6 @@ annotations | array | array of annotation data in the format `{id: string, pageN
       console.log('The id of selected annotation is', annotation.id);
       console.log('It is in page', annotation.pageNumber);
       console.log('Its type is', annotation.type);
-      console.log('Its lower left corner has coordinate', annotation.rect.x1, annotation.rect.y1);
     });
   }}
 />
@@ -2089,7 +2089,7 @@ this._viewer.setHighlightFields(true);
 ```
 
 
-#### getAnnotationAt
+#### getAnnotationAtPoint
 Gets an annotation at the (x, y) position in screen coordinates, if any.
 
 Parameters:
@@ -2107,10 +2107,10 @@ Promise Parameters:
 
 Name | Type | Description
 --- | --- | ---
-annotation | object | the annotation found in the format of `{id: string, pageNumber: number, type: string, rect: {x1: number, y1: number, x2: number, y2: number}}`
+annotation | object | the annotation found in the format of `{id: string, pageNumber: number, type: string, screenRect: {x1: number, y1: number, x2: number, y2: number, width: number, height: number}, pageRect: {x1: number, y1: number, x2: number, y2: number, width: number, height: number}}`. Type is one of the [`Config.Tools`](./src/Config/Config.js) constants. `screenRect` was formerly called `rect`.
 
 ```js
-this._viewer.getAnnotationAt(167, 287, 100, 10).then((annotation) => {
+this._viewer.getAnnotationAtPoint(167, 287, 100, 10).then((annotation) => {
   if (annotation) {
     console.log('Annotation found at point (167, 287) has id:', annotation.id);
   }
@@ -2118,7 +2118,7 @@ this._viewer.getAnnotationAt(167, 287, 100, 10).then((annotation) => {
 ```
 
 #### getAnnotationListAt
-Gets the list of annotations at a given line in screen coordinates. Note that this is not an area selection. It should be used similar to [`getAnnotationAt`](#getAnnotationAt), except that this should be used when you want to get multiple annotations which are overlaying with each other.
+Gets the list of annotations at a given line in screen coordinates. Note that this is not an area selection. It should be used similar to [`getAnnotationAtPoint`](#getAnnotationAtPoint), except that this should be used when you want to get multiple annotations which are overlaying with each other.
 
 Parameters:
 
@@ -2135,7 +2135,7 @@ Promise Parameters:
 
 Name | Type | Description
 --- | --- | ---
-annotations | array | list of annotations at the target line, each in the format of `{id: string, pageNumber: number, type: string, rect: {x1: number, y1: number, x2: number, y2: number}}`
+annotations | array | list of annotations at the target line, each in the format of `{id: string, pageNumber: number, type: string, screenRect: {x1: number, y1: number, x2: number, y2: number, width: number, height: number}, pageRect: {x1: number, y1: number, x2: number, y2: number, width: number, height: number}}`. Type is one of the [`Config.Tools`](./src/Config/Config.js) constants. `screenRect` was formerly called `rect`.
 
 ```js
 this._viewer.getAnnotationListAt(0, 0, 200, 200).then((annotations) => {
@@ -2145,7 +2145,7 @@ this._viewer.getAnnotationListAt(0, 0, 200, 200).then((annotations) => {
 })
 ```
 
-#### getAnnotationListOnPage
+#### getAnnotationsOnPage
 Gets the list of annotations on a given page.
 
 Parameters:
@@ -2160,10 +2160,10 @@ Promise Parameters:
 
 Name | Type | Description
 --- | --- | ---
-annotations | array | list of annotations on the target page, each in the format of `{id: string, pageNumber: number, type: string, rect: {x1: number, y1: number, x2: number, y2: number}}`
+annotations | array | list of annotations on the target page, each in the format of `{id: string, pageNumber: number, type: string, screenRect: {x1: number, y1: number, x2: number, y2: number, width: number, height: number}, pageRect: {x1: number, y1: number, x2: number, y2: number, width: number, height: number}}`. Type is one of the [`Config.Tools`](./src/Config/Config.js) constants. `screenRect` was formerly called `rect`.
 
 ```js
-this._viewer.getAnnotationListOnPage(2).then((annotations) => {
+this._viewer.getAnnotationsOnPage(2).then((annotations) => {
   for (const annotation of annotations) {
     console.log('Annotation found on page 2 has id:', annotation.id);
   }

--- a/ios/RNTPTDocumentView.h
+++ b/ios/RNTPTDocumentView.h
@@ -184,6 +184,8 @@ static NSString * const PTAbsoluteZoomLimitModeKey = @"absolute";
 static NSString * const PTRelativeZoomLimitModeKey = @"relative";
 
 static NSString * const PTRectKey = @"rect";
+static NSString * const PTScreenRectKey = @"screenRect";
+static NSString * const PTPageRectKey = @"pageRect";
 static NSString * const PTRectX1Key = @"x1";
 static NSString * const PTRectY1Key = @"y1";
 static NSString * const PTRectX2Key = @"x2";

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -2834,9 +2834,8 @@ NS_ASSUME_NONNULL_END
         uniqueId = [uniqueIdObj GetAsPDFText];
     }
     
-    PTPDFRect *screenRect = [pdfViewCtrl GetScreenRectForAnnot:annot
-                                                      page_num:pageNumber];
-    PTPDFRect *pageRect;
+    PTPDFRect *screenRect = [pdfViewCtrl GetScreenRectForAnnot:annot page_num:pageNumber];
+    PTPDFRect *pageRect = [self convertScreenRectToPageRect:screenRect pageNumber:pageNumber pdfViewCtrl:pdfViewCtrl];
     
     NSString *annotationType = [RNTPTDocumentView stringForAnnotType:[annot GetType]];
     
@@ -2844,13 +2843,36 @@ NS_ASSUME_NONNULL_END
         PTAnnotationIdKey: (uniqueId ?: @""),
         PTAnnotationPageNumberKey: @(pageNumber),
         PTAnnotationTypeKey: annotationType,
-        PTRectKey: @{
+        PTScreenRectKey: @{
                 PTRectX1Key: @([screenRect GetX1]),
                 PTRectY1Key: @([screenRect GetY1]),
                 PTRectX2Key: @([screenRect GetX2]),
                 PTRectY2Key: @([screenRect GetY2]),
+                PTRectWidthKey: @([screenRect Width]),
+                PTRectHeightKey: @([screenRect Height]),
+        },
+        PTPageRectKey: @{
+                PTRectX1Key: @([pageRect GetX1]),
+                PTRectY1Key: @([pageRect GetY1]),
+                PTRectX2Key: @([pageRect GetX2]),
+                PTRectY2Key: @([pageRect GetY2]),
+                PTRectWidthKey: @([pageRect Width]),
+                PTRectHeightKey: @([pageRect Height]),
         },
     };
+}
+
+- (PTPDFRect*)convertScreenRectToPageRect:(PTPDFRect*)screenRect pageNumber:(int)pageNumber pdfViewCtrl:(PTPDFViewCtrl *)pdfViewCtrl
+{
+    PTPDFPoint *screenRectPt1 = [[PTPDFPoint alloc] initWithPx:[screenRect GetX1] py:[screenRect GetY1]];
+    PTPDFPoint *screenRectPt2 = [[PTPDFPoint alloc] initWithPx:[screenRect GetX2] py:[screenRect GetY2]];
+    
+    PTPDFPoint *pageRectPt1 = [pdfViewCtrl ConvScreenPtToPagePt:screenRectPt1 page_num:pageNumber];
+    PTPDFPoint *pageRectPt2 = [pdfViewCtrl ConvScreenPtToPagePt:screenRectPt2 page_num:pageNumber];
+    
+    PTPDFRect* pageRect = [[PTPDFRect alloc] initWithX1:[pageRectPt1 getX] y1:[pageRectPt1 getY] x2:[pageRectPt2 getX] y2:[pageRectPt2 getY]];
+    
+    return pageRect;
 }
 
 - (NSArray<NSDictionary<NSString *, id> *> *)annotationDataForAnnotations:(NSArray<PTAnnot *> *)annotations pageNumber:(int)pageNumber pdfViewCtrl:(PTPDFViewCtrl *)pdfViewCtrl overrideAction:(bool)overrideAction

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -2836,6 +2836,7 @@ NS_ASSUME_NONNULL_END
     
     PTPDFRect *screenRect = [pdfViewCtrl GetScreenRectForAnnot:annot
                                                       page_num:pageNumber];
+    PTPDFRect *pageRect;
     
     NSString *annotationType = [RNTPTDocumentView stringForAnnotType:[annot GetType]];
     

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "2.0.3-beta.170",
+  "version": "2.0.3-beta.171",
   "description": "React Native Pdftron",
   "main": "index.js",
   "scripts": {

--- a/src/DocumentView/DocumentView.js
+++ b/src/DocumentView/DocumentView.js
@@ -227,7 +227,7 @@ export default class DocumentView extends PureComponent {
       }
     } else if (event.nativeEvent.onTextSearchStart) {
       if (this.props.onTextSearchStart) {
-        this.props.onTextSearchStart(event.nativeEvent.onTextSearchStart);
+        this.props.onTextSearchStart();
       }
     } else if (event.nativeEvent.onTextSearchResult) {
       if (this.props.onTextSearchResult) {


### PR DESCRIPTION
Some iOS methods returned a `rect` value while the Android counterparts returned `screenRect` and `pageRect`. This update makes the iOS methods consistent with the Android ones by replacing `rect` with `screenRect` and `pageRect`. 

This update affects the following methods:
- `getAnnotationAtPoint`
- `getAnnotationListAt`
- `getAnnotationsOnPage`
- `onAnnotationMenuPress`
- `onAnnotationsSelected`
- `onBehaviorActivated`

This update also fixes a few unrelated typos or wordings in `API.md`.