### PR TITLE
Comment out excludedAnnotationTypes

### DIFF
--- a/API.md
+++ b/API.md
@@ -1264,6 +1264,19 @@ Defines types to be excluded from the annotation list. This feature will be soon
 pod 'PDFNet', podspec: 'https://nightly-pdftron.s3-us-west-2.amazonaws.com/stable/2021-08-04/9.0/cocoapods/xcframeworks/pdfnet/2021-08-04_stable_rev77892.podspec'
 ```
 
+and uncomment the following line in `ios/RNTPTDocumentView.m`:
+```objc
+- (void)excludeAnnotationListTypes:(NSArray<NSString*> *)excludedAnnotationListTypes documentViewController:(PTDocumentBaseViewController *)documentViewController
+{
+    ...
+    if (annotTypes.count > 0) {
+        //documentViewController.navigationListsViewController.annotationViewController.excludedAnnotationTypes = annotTypes;
+    }
+}
+```
+
+Example use:
+
 ```js
 <DocumentView
   excludedAnnotationListTypes={[Config.Tools.annotationCreateEllipse, Config.Tools.annotationCreateRectangle, Config.Tools.annotationCreateRedaction]}

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -590,7 +590,7 @@ NS_ASSUME_NONNULL_END
     }
     
     if (annotTypes.count > 0) {
-        documentViewController.navigationListsViewController.annotationViewController.excludedAnnotationTypes = annotTypes;
+        //documentViewController.navigationListsViewController.annotationViewController.excludedAnnotationTypes = annotTypes;
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "2.0.3-beta.162",
+  "version": "2.0.3-beta.163",
   "description": "React Native Pdftron",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Comment out call to native API `excludedAnnotationTypes` which will be in future version.