### PR TITLE
(Android) getAnnotationsData WritableMap fix

### DIFF
--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -1917,7 +1917,8 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
 
                 if (annotationData != null) {
                     if (overrideAction && isOverrideAction(KEY_CONFIG_STICKY_NOTE_SHOW_POP_UP)) {
-                        WritableMap annotationDataCopy = annotationData.copy();
+                        WritableMap annotationDataCopy = Arguments.createMap();
+                        annotationDataCopy.merge(annotationData);
                         try {
                             if (entry.getKey().getType() == Annot.e_Text) {
                                 WritableMap params = Arguments.createMap();

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "2.0.3-beta.169",
+  "version": "2.0.3-beta.170",
   "description": "React Native Pdftron",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
In Android `getAnnotationsData` method, replaced `WritableMap.copy` with `WritableMap.merge` (`copy` doesn't exist in RN 0.60.0).