### PR TITLE
(support, Android) expose getSavedSignatureJpgFolder

### DIFF
--- a/API.md
+++ b/API.md
@@ -3124,7 +3124,9 @@ this._viewer.getSavedSignatures().then((signatures) => {
 ```
 
 #### getSavedSignatureFolder
-Retrieves the absolute file path to the folder containing the saved signatures
+Retrieves the absolute file path to the folder containing the saved signature PDFs.
+
+For Android, to get the folder containing the saved signature JPGs, use [`getSavedSignatureJpgFolder`](#getSavedSignatureJpgFolder).
 
 Returns a Promise.
 
@@ -3136,6 +3138,27 @@ path | string | the absolute file path to the folder
 
 ```js
 this._viewer.getSavedSignatureFolder().then((path) => {
+  if (path != null) {
+    console.log(path);
+  }
+})
+```
+
+#### getSavedSignatureJpgFolder
+Retrieves the absolute file path to the folder containing the saved signature JPGs. Android only.
+
+To get the folder containing the saved signature PDFs, use [`getSavedSignatureFolder`](#getSavedSignatureFolder).
+
+Returns a Promise.
+
+Promise Parameters:
+
+Name | Type | Description
+--- | --- | ---
+path | string | the absolute file path to the folder
+
+```js
+this._viewer.getSavedSignatureJpgFolder().then((path) => {
   if (path != null) {
     console.log(path);
   }

--- a/android/src/main/java/com/pdftron/reactnative/modules/DocumentViewModule.java
+++ b/android/src/main/java/com/pdftron/reactnative/modules/DocumentViewModule.java
@@ -1413,6 +1413,21 @@ public class DocumentViewModule extends ReactContextBaseJavaModule implements Ac
         });
     }
 
+    @ReactMethod
+    public void getSavedSignatureJpgFolder(final int tag, final Promise promise) {
+        getReactApplicationContext().runOnUiQueueThread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    String result = mDocumentViewInstance.getSavedSignatureJpgFolder(tag);
+                    promise.resolve(result);
+                } catch (Exception e) {
+                    promise.reject(e);
+                }
+            }
+        });
+    }
+
     @Override
     public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {
         mDocumentViewInstance.onActivityResult(requestCode, resultCode, data);

--- a/android/src/main/java/com/pdftron/reactnative/viewmanagers/DocumentViewViewManager.java
+++ b/android/src/main/java/com/pdftron/reactnative/viewmanagers/DocumentViewViewManager.java
@@ -1273,6 +1273,15 @@ public class DocumentViewViewManager extends ViewGroupManager<DocumentView> {
         }
     }
 
+    public String getSavedSignatureJpgFolder(int tag) throws PDFNetException {
+        DocumentView documentView = mDocumentViews.get(tag);
+        if (documentView != null) {
+            return documentView.getSavedSignatureJpgFolder();
+        } else {
+            throw new PDFNetException("", 0L, getName(), "getSavedSignatureJpgFolder", "Unable to find DocumentView.");
+        }
+    }
+
     @Override
     public boolean needsCustomLayoutForChildren() {
         return true;

--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -4213,6 +4213,15 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
         }
         return "";
     }
+
+    public String getSavedSignatureJpgFolder() {
+        Context context = getContext();
+        if (context != null) {
+            File file = StampManager.getInstance().getSavedSignatureJpgFolder(context);
+            return file.getAbsolutePath();
+        }
+        return "";
+    }
     
     public void setSaveStateEnabled(boolean saveStateEnabled) {
         mSaveStateEnabled = saveStateEnabled;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "2.0.3-beta.180",
+  "version": "2.0.3-beta.181",
   "description": "React Native Pdftron",
   "main": "index.js",
   "scripts": {

--- a/src/DocumentView/DocumentView.js
+++ b/src/DocumentView/DocumentView.js
@@ -1031,6 +1031,14 @@ export default class DocumentView extends PureComponent {
     return Promise.resolve();
   }
 
+  getSavedSignatureJpgFolder = () => {
+    const tag = findNodeHandle(this._viewerRef);
+    if (tag != null) {
+       return DocumentViewManager.getSavedSignatureJpgFolder(tag);
+    }
+    return Promise.resolve();
+  }
+
   _setNativeRef = (ref) => {
     this._viewerRef = ref;
   };


### PR DESCRIPTION
Exposed Android `getSavedSignatureJpgFolder` which retrieves the absolute file path to the folder containing the saved signature JPGs. 