### PR TITLE
[Support] Add Back to pan tool

### DIFF
--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -1886,6 +1886,9 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
 
     @Override
     public void onNavButtonPressed() {
+        if (getToolManager() != null) {
+            getToolManager().setTool(getToolManager().createTool(ToolManager.ToolMode.PAN, null));
+        }
         onReceiveNativeEvent(ON_NAV_BUTTON_PRESSED, ON_NAV_BUTTON_PRESSED);
     }
 


### PR DESCRIPTION
Add Back to pan tool

## Support Ticket
https://support.pdftron.com/a/tickets/25629

## Issues Closed or Referenced
closes #5809

## Description of Changes
- add back to pan tool to fix pressing back crash after the draw and calibrate with the measure tool

## Screenshots
