### PR TITLE
Fixed typo in the annotation manager mode props

### DIFF
--- a/API.md
+++ b/API.md
@@ -1180,7 +1180,7 @@ Sets annotation manager edit mode when [`collabEnabled`](#collabEnabled) is true
 Mode | Description
 --- | ---
 `Config.AnnotationManagerEditMode.Own` | In this mode, you can edit only your own changes 
-`Config.AnnotationManagerEditMode.Others` | In this mode, you can edit everyone's changes 
+`Config.AnnotationManagerEditMode.All` | In this mode, you can edit everyone's changes 
 
 ```js
 <DocumentView
@@ -1198,7 +1198,7 @@ Sets annotation manager undo mode when [`collabEnabled`](#collabEnabled) is true
 Mode | Description
 --- | ---
 `Config.AnnotationManagerUndoMode.Own` | In this mode, you can undo only your own changes 
-`Config.AnnotationManagerUndoMode.Others` | In this mode, you can undo everyone's changes 
+`Config.AnnotationManagerUndoMode.All` | In this mode, you can undo everyone's changes 
 
 ```js
 <DocumentView


### PR DESCRIPTION
In the table describing the modes associated with `annotationManagerEditMode` and `annotationManagerUndoMode`, `Config.AnnotationManagerEditMode.Others` was used instead of `Config.AnnotationManagerEditMode.All` and `Config.AnnotationManagerUndoMode.Others` was used instead of `Config.AnnotationManagerUndoMode.All`.