### PR TITLE
(Android) Updated `showQuickNavigationButton`

### DIFF
--- a/API.md
+++ b/API.md
@@ -1662,6 +1662,8 @@ Defines whether to restrict data usage when viewing online PDFs.
 #### pageStackEnabled
 bool, optional, defaults to true, Android only
 
+Deprecated. Use the [`showQuickNavigationButton`](#showQuickNavigationButton) prop instead.
+
 Defines whether the page stack navigation buttons will appear in the viewer.
 
 ```js

--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -889,7 +889,7 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
     }
 
     public void setShowQuickNavigationButton(boolean showQuickNavigationButton) {
-        mBuilder = mBuilder.showQuickNavigationButton(showQuickNavigationButton);
+        mBuilder = mBuilder.pageStackEnabled(showQuickNavigationButton);
     }
 
     public void setPhotoPickerEnabled(boolean photoPickerEnabled) {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "3.0.2-beta.21",
+  "version": "3.0.2-beta.22",
   "description": "React Native Pdftron",
   "main": "./lib/index.js",
   "typings": "index.ts",


### PR DESCRIPTION
After a discussion with Shirley, we realised that `pageStackEnabled` and `showQuickNavigationButton` were doing the same thing on Android but the latter was a worse implementation. 

Since, latter was working properly on iOS, we decided to copy over former's implementation and then deprecate `pageStackEnabled`.