### PR TITLE
(iOS) Update annotationsListEditingEnabled

### DIFF
--- a/API.md
+++ b/API.md
@@ -1425,11 +1425,9 @@ fields | array | array of field data in the format `{fieldName: string, fieldTyp
 ```
 
 #### annotationsListEditingEnabled
-bool, optional, Android only, default value is true
+bool, optional, default value is true
 
 If document editing is enabled, then this value determines if the annotation list is editable. 
-
-Functionality for iOS will fixed in the next official release, or a fixed version is available by pointing the iOS podfile to https://nightly-pdftron.s3-us-west-2.amazonaws.com/stable/2021-06-30/9.0/cocoapods/pdfnet/2021-06-30_stable_rev77837.podspec as described in step one of the [iOS integration instructions](https://github.com/PDFTron/pdftron-react-native#ios).
 
 
 ```js

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -152,6 +152,7 @@ NS_ASSUME_NONNULL_END
     
     _showSavedSignatures = YES;
 
+    _annotationsListEditingEnabled = YES;
     _userBookmarksListEditingEnabled = YES;
     
     _showQuickNavigationButton = YES;
@@ -2030,7 +2031,7 @@ NS_ASSUME_NONNULL_END
     [self applyCustomHeaders:documentViewController];
 
     // Set Annotation List Editing 
-//     documentViewController.navigationListsViewController.annotationViewController.readonly = !self.annotationsListEditingEnabled;
+     documentViewController.navigationListsViewController.annotationViewController.readonly = !self.annotationsListEditingEnabled;
     
     // Exclude annotation types from annotation list.
     [self excludeAnnotationListTypes:self.excludedAnnotationListTypes documentViewController:documentViewController];


### PR DESCRIPTION
This PR:
- uncomments `annotationsListEditingEnabled` call since it is available now
- initialises value to true