### PR TITLE
(iOS) Updated implementation of `annotationManagerEditMode`

### DIFF
--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -2065,9 +2065,11 @@ NS_ASSUME_NONNULL_END
     // Annotation Manager Edit Mode
     if ([PTAnnotationManagerEditModeOwn isEqualToString:self.annotationManagerEditMode]) {
         documentViewController.toolManager.annotationManager.annotationEditMode = PTAnnotationModeEditOwn;
+        documentViewController.toolManager.annotationAuthorCheckEnabled = YES;
         documentViewController.toolManager.annotationPermissionCheckEnabled = YES;
     } else if ([PTAnnotationManagerEditModeAll isEqualToString:self.annotationManagerEditMode]) {
         documentViewController.toolManager.annotationManager.annotationEditMode = PTAnnotationModeEditAll;
+        documentViewController.toolManager.annotationAuthorCheckEnabled = YES;
         documentViewController.toolManager.annotationPermissionCheckEnabled = YES;
     }
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "3.0.2-beta.24",
+  "version": "3.0.2-beta.25",
   "description": "React Native Pdftron",
   "main": "./lib/index.js",
   "typings": "index.ts",


### PR DESCRIPTION
While working on the annotation manager modes for Flutter, David and I noticed an issue in the React Native implementation. This PR fixes that probem.