### PR TITLE
(Support) Disable Insert Pages Button

### DIFF
--- a/android/src/main/java/com/pdftron/reactnative/utils/Constants.java
+++ b/android/src/main/java/com/pdftron/reactnative/utils/Constants.java
@@ -77,6 +77,7 @@ public final class Constants {
     public static final String TOOL_BUTTON_STAMP = "stampToolButton";
     public static final String TOOL_BUTTON_EDIT = "editToolButton";
     public static final String TOOL_BUTTON_ADD_PAGE = "addPageButton";
+    public static final String TOOL_BUTTON_INSERT_PAGE = "insertPageButton";
 
     // TOOLS
     public static final String TOOL_ANNOTATION_CREATE_FREE_HAND = "AnnotationCreateFreeHand";
@@ -123,6 +124,7 @@ public final class Constants {
     public static final String TOOL_ANNOTATION_CREATE_SMART_PEN = "AnnotationCreateSmartPen";
     public static final String TOOL_ANNOTATION_CREATE_FREE_TEXT_DATE = "AnnotationCreateFreeTextDate";
     public static final String TOOL_ANNOTATION_CREATE_FREE_SPACING_TEXT = "AnnotationCreateFreeSpacingText";
+    public static final String TOOL_INSERT_PAGE = "InsertPage";
 
     // Field types
     public static final String FIELD_TYPE_UNKNOWN = "unknown";

--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -1013,7 +1013,9 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
     private void disableTools(ReadableArray args) {
         for (int i = 0; i < args.size(); i++) {
             String item = args.getString(i);
-            if (TOOL_BUTTON_ADD_PAGE.equals(item)) {
+            if (TOOL_BUTTON_ADD_PAGE.equals(item) ||
+                    TOOL_BUTTON_INSERT_PAGE.equals(item) ||
+                    TOOL_INSERT_PAGE.equals(item)) {
                 mShowAddPageToolbarButton = false;
             }
             ToolManager.ToolMode mode = convStringToToolMode(item);

--- a/ios/RNTPTDocumentView.h
+++ b/ios/RNTPTDocumentView.h
@@ -49,6 +49,7 @@ static NSString * const PTEllipseToolButtonKey = @"ellipseToolButton";
 static NSString * const PTPolygonToolButtonKey = @"polygonToolButton";
 static NSString * const PTCloudToolButtonKey = @"cloudToolButton";
 static NSString * const PTEditToolButtonKey = @"editToolButton";
+static NSString * const PTInsertPageButton = @"insertPageButton";
 
 static NSString * const PTAnnotationEditToolKey = @"AnnotationEdit";
 static NSString * const PTAnnotationCreateStickyToolKey = @"AnnotationCreateSticky";
@@ -91,6 +92,7 @@ static NSString * const PTFormCreateSignatureFieldToolKey = @"FormCreateSignatur
 static NSString * const PTFormCreateRadioFieldToolKey = @"FormCreateRadioField";
 static NSString * const PTFormCreateComboBoxFieldToolKey = @"FormCreateComboBoxField";
 static NSString * const PTFormCreateListBoxFieldToolKey = @"FormCreateListBoxField";
+static NSString * const PTInsertPageToolKey = @"InsertPage";
 
 static NSString * const PTHiddenAnnotationFlagKey = @"hidden";
 static NSString * const PTInvisibleAnnotationFlagKey = @"invisible";

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -626,6 +626,14 @@ NS_ASSUME_NONNULL_END
         },
         PTEditPagesButtonKey: ^{
             documentViewController.addPagesButtonHidden = YES;
+            if( [documentViewController isKindOfClass:[PTDocumentController class]] )
+            {
+                PTToolGroupManager *toolGroupManager = ((PTDocumentController*)documentViewController).toolGroupManager;
+                PTToolGroup *insertItemGroup = toolGroupManager.insertItemGroup;
+                NSMutableArray<UIBarButtonItem *> *barButtonItems = [insertItemGroup.barButtonItems mutableCopy];
+                [barButtonItems removeObject:toolGroupManager.addPagesButtonItem];
+                insertItemGroup.barButtonItems = [barButtonItems copy];
+            }
         },
         PTEditMenuButtonKey: ^{
             if( [documentViewController isKindOfClass:[PTDocumentController class]] )

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -824,6 +824,14 @@ NS_ASSUME_NONNULL_END
                      [string isEqualToString:PTCloudToolButtonKey]) {
                 toolManager.cloudyAnnotationOptions.canCreate = value;
             }
+            else if ([string isEqualToString:PTInsertPageToolKey] ||
+                     [string isEqualToString:PTInsertPageButton]) {
+                PTToolGroupManager *toolGroupManager = ((PTDocumentController*)documentViewController).toolGroupManager;
+                PTToolGroup *insertItemGroup = toolGroupManager.insertItemGroup;
+                NSMutableArray<UIBarButtonItem *> *barButtonItems = [insertItemGroup.barButtonItems mutableCopy];
+                [barButtonItems removeObject:toolGroupManager.addPagesButtonItem];
+                insertItemGroup.barButtonItems = [barButtonItems copy];
+            }
             else if ([string isEqualToString:PTAnnotationCreateFileAttachmentToolKey]) {
                 toolManager.fileAttachmentAnnotationOptions.canCreate = value;
             }

--- a/lib/src/Config/Config.js
+++ b/lib/src/Config/Config.js
@@ -46,6 +46,7 @@ export const Config = {
         undo: 'undo',
         redo: 'redo',
         addPageButton: 'addPageButton',
+        insertPageButton: 'insertPageButton',
         // Android only
         saveReducedCopyButton: 'saveReducedCopyButton',
         saveCroppedCopyButton: 'saveCroppedCopyButton',
@@ -93,6 +94,7 @@ export const Config = {
         formCreateRadioField: 'FormCreateRadioField',
         formCreateComboBoxField: 'FormCreateComboBoxField',
         formCreateListBoxField: 'FormCreateListBoxField',
+        insertPage: 'InsertPage',
         // iOS only.
         pencilKitDrawing: 'PencilKitDrawing',
     },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "3.0.2-beta.29",
+  "version": "3.0.2-beta.30",
   "description": "React Native Pdftron",
   "main": "./lib/index.js",
   "typings": "index.ts",

--- a/src/Config/Config.ts
+++ b/src/Config/Config.ts
@@ -47,6 +47,7 @@ export const Config = {
     undo: 'undo',
     redo: 'redo',
     addPageButton: 'addPageButton',
+    insertPageButton: 'insertPageButton',
 
     // Android only
     saveReducedCopyButton: 'saveReducedCopyButton',
@@ -96,6 +97,7 @@ export const Config = {
     formCreateRadioField: 'FormCreateRadioField',
     formCreateComboBoxField: 'FormCreateComboBoxField',
     formCreateListBoxField: 'FormCreateListBoxField',
+    insertPage: 'InsertPage',
 
     // iOS only.
     pencilKitDrawing: 'PencilKitDrawing',


### PR DESCRIPTION
* (iOS) Added support to disable `insertPages` button using either `disabledTools` or `disabledElements`.
* (iOS) Disable `insertPages` button when disabling `editPages` button.
* (Android) Add support for the `Config.Tools.insertPage` and `Config.Buttons.insertPageButton` constants in `disabledTools` and `disabledElements`