### PR TITLE
[Android] Fix issue where empty custom toolbar title can not be used

### DIFF
--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -728,7 +728,7 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
                             toolbarItems = map.getArray(toolbarKey);
                         }
                     }
-                    if (!Utils.isNullOrEmpty(tag) && !Utils.isNullOrEmpty(toolbarName) &&
+                    if (!Utils.isNullOrEmpty(tag) && toolbarName != null &&
                             toolbarItems != null && toolbarItems.size() > 0) {
                         AnnotationToolbarBuilder toolbarBuilder = AnnotationToolbarBuilder.withTag(tag)
                                 .setToolbarName(toolbarName)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "3.0.2-beta.39",
+  "version": "3.0.2-beta.40",
   "description": "React Native Pdftron",
   "main": "./lib/index.js",
   "typings": "index.ts",


### PR DESCRIPTION
### Steps to reproduce issue:
Call the following custom toolbar (note empty toolbar name)
const myToolbar = {
[Config.CustomToolbarKey.Id]: 'myToolbar',
[Config.CustomToolbarKey.Name]: '',
[Config.CustomToolbarKey.Icon]: Config.ToolbarIcons.Annotate,
[Config.CustomToolbarKey.Items]: [Config.Tools.annotationCreateTextHighlight,
Config.Tools.annotationCreateFreeHighlighter,
Config.Tools.annotationCreateFreeText,
Config.Tools.annotationEraserTool,
Config.Buttons.undo,
Config.Buttons.redo
]
};

...
annotationToolbars={[myToolbar]}

The custom toolbar will not be used. If the toolbar title is non empty, then it will work.

### Description
This PR fixes this issue to allow for empty toolbar names.