### PR TITLE
fixing initial Page number bug

### DIFF
--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -3056,11 +3056,7 @@ NS_ASSUME_NONNULL_END
 #pragma mark - <RNTPTDocumentViewControllerDelegate>
 
 - (void)rnt_documentViewControllerDocumentLoaded:(PTDocumentBaseViewController *)documentViewController
-{
-    if (self.initialPageNumber > 0) {
-        [documentViewController.pdfViewCtrl SetCurrentPage:self.initialPageNumber];
-    }
-        
+{       
     if ([self isReadOnly] && ![documentViewController.toolManager isReadonly]) {
         documentViewController.toolManager.readonly = YES;
     }
@@ -3573,6 +3569,10 @@ NS_ASSUME_NONNULL_END
 
     if (documentViewController != self.currentDocumentViewController) {
         return;
+    }
+
+    if (self.initialPageNumber > 0) {
+        [documentViewController.pdfViewCtrl SetCurrentPage:self.initialPageNumber];
     }
     
     if ([self isReadOnly] && ![documentViewController.toolManager isReadonly]) {


### PR DESCRIPTION
### Bug
* When you set initialPageNumber prop in React-Native the iOS app does not set the page number in the document that is loaded

### Changes
* changed the location of check for initialPageNumber prop value check 