### PR TITLE
fix for forked repos

### DIFF
--- a/.github/workflows/npm_publish.yml
+++ b/.github/workflows/npm_publish.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   build:
+    if: github.repository == 'PDFTron/pdftron-react-native'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
the conditional statement prevents the first job from being executed, and since the second job depends on the first job it will be skipped since the first job failed to execute