### PR TITLE
Enable/disable annotation toolbar item CPM-4

### DIFF
--- a/API.md
+++ b/API.md
@@ -852,29 +852,6 @@ Defines whether the viewer will add padding to take account of the system status
 />
 ```
 
-#### setAnnotationToolbarItemEnabled
-Sets the annotation toolbar item corresponding to the given string key enabled/disabled.
-
-Returns a Promise.
-
-Parameters:
-
-Name | Type    | Description
---- |---------| ---
-itemId | string  | one of the constants defined in `Config.Tools` or the `Config.CustomToolItemKey.Id` defined in a custom tool item object
-enable | boolean | whether to enable or disable the item
-
-```js
-this._viewer
-  .setAnnotationToolbarItemEnabled(
-    'add_page',
-    false,
-  )
-  .then(() => {
-    console.log('disabled');
-  });
-```
-
 ### Layout
 
 #### fitMode
@@ -2194,6 +2171,29 @@ committed | bool | true if either ink or poly-shape tool is committed, false oth
 this._viewer.commitTool().then((committed) => {
   // committed: true if either ink or poly-shape tool is committed, false otherwise
 });
+```
+
+#### setAnnotationToolbarItemEnabled
+Sets the annotation toolbar item corresponding to the given string key enabled/disabled.
+
+Returns a Promise.
+
+Parameters:
+
+Name | Type    | Description
+--- |---------| ---
+itemId | string  | one of the constants defined in `Config.Tools` or the `Config.CustomToolItemKey.Id` defined in a custom tool item object
+enable | boolean | whether to enable or disable the item
+
+```js
+this._viewer
+  .setAnnotationToolbarItemEnabled(
+    Config.Tools.annotationCreateSignature,
+    false,
+  )
+  .then(() => {
+    console.log('disabled');
+  });
 ```
 
 ### Page

--- a/API.md
+++ b/API.md
@@ -852,6 +852,29 @@ Defines whether the viewer will add padding to take account of the system status
 />
 ```
 
+#### setAnnotationToolbarItemEnabled
+Sets the annotation toolbar item corresponding to the given string key enabled/disabled.
+
+Returns a Promise.
+
+Parameters:
+
+Name | Type    | Description
+--- |---------| ---
+itemId | string  | one of the constants defined in `Config.Tools` or the `Config.CustomToolItemKey.Id` defined in a custom tool item object
+enable | boolean | whether to enable or disable the item
+
+```js
+this._viewer
+  .setAnnotationToolbarItemEnabled(
+    'add_page',
+    false,
+  )
+  .then(() => {
+    console.log('disabled');
+  });
+```
+
 ### Layout
 
 #### fitMode

--- a/android/src/main/java/com/pdftron/reactnative/modules/DocumentViewModule.java
+++ b/android/src/main/java/com/pdftron/reactnative/modules/DocumentViewModule.java
@@ -364,7 +364,7 @@ public class DocumentViewModule extends ReactContextBaseJavaModule implements Ac
     }
 
     @ReactMethod
-    public void setAnnotationToolbarItemEnabled(final int tag, final int itemId, final boolean enable, final Promise promise) {
+    public void setAnnotationToolbarItemEnabled(final int tag, final String itemId, final boolean enable, final Promise promise) {
         getReactApplicationContext().runOnUiQueueThread(new Runnable() {
             @Override
             public void run() {

--- a/android/src/main/java/com/pdftron/reactnative/modules/DocumentViewModule.java
+++ b/android/src/main/java/com/pdftron/reactnative/modules/DocumentViewModule.java
@@ -364,6 +364,21 @@ public class DocumentViewModule extends ReactContextBaseJavaModule implements Ac
     }
 
     @ReactMethod
+    public void setAnnotationToolbarItemEnabled(final int tag, final int itemId, final boolean enable, final Promise promise) {
+        getReactApplicationContext().runOnUiQueueThread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    mDocumentViewInstance.setAnnotationToolbarItemEnabled(tag, itemId, enable);
+                    promise.resolve(null);
+                } catch (Exception e) {
+                    promise.reject(e);
+                }
+            }
+        });
+    }
+
+    @ReactMethod
     public void handleBackButton(final int tag, final Promise promise) {
         getReactApplicationContext().runOnUiQueueThread(new Runnable() {
             @Override

--- a/android/src/main/java/com/pdftron/reactnative/nativeviews/RNPdfViewCtrlTabHostFragment.java
+++ b/android/src/main/java/com/pdftron/reactnative/nativeviews/RNPdfViewCtrlTabHostFragment.java
@@ -27,4 +27,8 @@ public class RNPdfViewCtrlTabHostFragment extends PdfViewCtrlTabHostFragment2 {
             mListener.onHostFragmentViewCreated();
         }
     }
+
+    public void setItemEnabled(int itemId, boolean enabled) {
+        mAnnotationToolbarComponent.setItemEnabled(itemId, enabled);
+    }
 }

--- a/android/src/main/java/com/pdftron/reactnative/viewmanagers/DocumentViewViewManager.java
+++ b/android/src/main/java/com/pdftron/reactnative/viewmanagers/DocumentViewViewManager.java
@@ -727,6 +727,15 @@ public class DocumentViewViewManager extends ViewGroupManager<DocumentView> {
         }
     }
 
+    public void setAnnotationToolbarItemEnabled(int tag, int itemId, boolean enable) throws PDFNetException {
+        DocumentView documentView = mDocumentViews.get(tag);
+        if (documentView != null) {
+            documentView.setAnnotationToolbarItemEnabled(itemId, enable);
+        } else {
+            throw new PDFNetException("", 0L, getName(), "setAnnotationToolbarItemEnabled", "Unable to find DocumentView.");
+        }
+    }
+
     public boolean handleBackButton(int tag) throws PDFNetException {
         DocumentView documentView = mDocumentViews.get(tag);
         if (documentView != null) {

--- a/android/src/main/java/com/pdftron/reactnative/viewmanagers/DocumentViewViewManager.java
+++ b/android/src/main/java/com/pdftron/reactnative/viewmanagers/DocumentViewViewManager.java
@@ -727,7 +727,7 @@ public class DocumentViewViewManager extends ViewGroupManager<DocumentView> {
         }
     }
 
-    public void setAnnotationToolbarItemEnabled(int tag, int itemId, boolean enable) throws PDFNetException {
+    public void setAnnotationToolbarItemEnabled(int tag, String itemId, boolean enable) throws PDFNetException {
         DocumentView documentView = mDocumentViews.get(tag);
         if (documentView != null) {
             documentView.setAnnotationToolbarItemEnabled(itemId, enable);

--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -840,25 +840,9 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
                 }
             }
         }
-        mBuilder.addToolbarBuilder(demoCodeOnly()); // !!
         if (mPdfViewCtrlTabHostFragment != null) {
             mPdfViewCtrlTabHostFragment.setAnnotationToolbars(annotationToolbarBuilders);
         }
-    }
-
-    // !!
-    private AnnotationToolbarBuilder demoCodeOnly() {
-        int id = mToolIdGenerator.getAndIncrement();
-        mToolIdMap.put(id, "demo-button");
-        return AnnotationToolbarBuilder.withTag("Demo-Toolbar") // Identifier for toolbar
-                .setToolbarName("Demo Toolbar") // Name used when displaying toolbar
-                .addToolButton(ToolbarButtonType.INK, 1)
-                .addToolButton(ToolbarButtonType.STICKY_NOTE, 2)
-                .addToolButton(ToolbarButtonType.TEXT_HIGHLIGHT, 3)
-                .addToolStickyButton(ToolbarButtonType.UNDO, DefaultToolbars.ButtonId.UNDO.value())
-                .addToolStickyButton(ToolbarButtonType.REDO, DefaultToolbars.ButtonId.REDO.value())
-                .addCustomStickyButton("info", R.drawable.ic_bx_download, id)
-                ;
     }
 
     private boolean isValidToolbarTag(String tag) {
@@ -2170,8 +2154,6 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
     public boolean onToolbarOptionsItemSelected(MenuItem item) {
         int itemId = item.getItemId();
         String itemKey = mToolIdMap.get(itemId);
-        // !!
-        setAnnotationToolbarItemEnabled(TOOL_ANNOTATION_CREATE_SIGNATURE, false);
         if (itemKey != null) {
             // this is a custom button
             WritableMap params = Arguments.createMap();

--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -3501,8 +3501,12 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
             mPdfViewCtrlTabHostFragment instanceof RNPdfViewCtrlTabHostFragment) {
             int buttonId = convStringToButtonId(itemId);
             if (buttonId == 0) {
-                int index = mToolIdMap.indexOfValue(itemId);
-                buttonId = mToolIdMap.keyAt(index);
+                for (int i = 0; i < mToolIdMap.size(); i++) {
+                    if (mToolIdMap.valueAt(i).equals(itemId)) {
+                        buttonId = mToolIdMap.keyAt(i);
+                        break;
+                    }
+                }
             }
             ((RNPdfViewCtrlTabHostFragment) mPdfViewCtrlTabHostFragment).setItemEnabled(buttonId, enable);
         }

--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -2170,6 +2170,8 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
     public boolean onToolbarOptionsItemSelected(MenuItem item) {
         int itemId = item.getItemId();
         String itemKey = mToolIdMap.get(itemId);
+        // !!
+        setAnnotationToolbarItemEnabled(TOOL_ANNOTATION_CREATE_SIGNATURE, false);
         if (itemKey != null) {
             // this is a custom button
             WritableMap params = Arguments.createMap();
@@ -3512,10 +3514,15 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
         return customData;
     }
 
-    public void setAnnotationToolbarItemEnabled(int itemId, boolean enable) {
+    public void setAnnotationToolbarItemEnabled(String itemId, boolean enable) {
         if (mPdfViewCtrlTabHostFragment != null &&
             mPdfViewCtrlTabHostFragment instanceof RNPdfViewCtrlTabHostFragment) {
-            ((RNPdfViewCtrlTabHostFragment) mPdfViewCtrlTabHostFragment).setItemEnabled(itemId, enable);
+            int buttonId = convStringToButtonId(itemId);
+            if (buttonId == 0) {
+                int index = mToolIdMap.indexOfValue(itemId);
+                buttonId = mToolIdMap.keyAt(index);
+            }
+            ((RNPdfViewCtrlTabHostFragment) mPdfViewCtrlTabHostFragment).setItemEnabled(buttonId, enable);
         }
     }
 

--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -840,9 +840,25 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
                 }
             }
         }
+        mBuilder.addToolbarBuilder(demoCodeOnly()); // !!
         if (mPdfViewCtrlTabHostFragment != null) {
             mPdfViewCtrlTabHostFragment.setAnnotationToolbars(annotationToolbarBuilders);
         }
+    }
+
+    // !!
+    private AnnotationToolbarBuilder demoCodeOnly() {
+        int id = mToolIdGenerator.getAndIncrement();
+        mToolIdMap.put(id, "demo-button");
+        return AnnotationToolbarBuilder.withTag("Demo-Toolbar") // Identifier for toolbar
+                .setToolbarName("Demo Toolbar") // Name used when displaying toolbar
+                .addToolButton(ToolbarButtonType.INK, 1)
+                .addToolButton(ToolbarButtonType.STICKY_NOTE, 2)
+                .addToolButton(ToolbarButtonType.TEXT_HIGHLIGHT, 3)
+                .addToolStickyButton(ToolbarButtonType.UNDO, DefaultToolbars.ButtonId.UNDO.value())
+                .addToolStickyButton(ToolbarButtonType.REDO, DefaultToolbars.ButtonId.REDO.value())
+                .addCustomStickyButton("info", R.drawable.ic_bx_download, id)
+                ;
     }
 
     private boolean isValidToolbarTag(String tag) {
@@ -3494,6 +3510,13 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
         }
 
         return customData;
+    }
+
+    public void setAnnotationToolbarItemEnabled(int itemId, boolean enable) {
+        if (mPdfViewCtrlTabHostFragment != null &&
+            mPdfViewCtrlTabHostFragment instanceof RNPdfViewCtrlTabHostFragment) {
+            ((RNPdfViewCtrlTabHostFragment) mPdfViewCtrlTabHostFragment).setItemEnabled(itemId, enable);
+        }
     }
 
     public void setValuesForFields(ReadableMap readableMap) throws PDFNetException {

--- a/ios/RNTPTDocumentView.h
+++ b/ios/RNTPTDocumentView.h
@@ -583,6 +583,8 @@ static NSString * const PTSignaturesManager_signatureDirectory = @"PTSignaturesM
 - (NSString *)getCustomDataForAnnotation: (NSString *)annotationId
     pageNumber:(NSInteger)pageNumber key:(NSString *)key;
 
+- (void)setAnnotationToolbarItemEnabled:(NSString *)itemId enable:(BOOL)enable;
+
 - (NSDictionary<NSString *, NSNumber *> *)getPageCropBox:(NSInteger)pageNumber;
 
 - (bool)setCurrentPage:(NSInteger)pageNumber;

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -1846,6 +1846,42 @@ NS_ASSUME_NONNULL_END
     [self applyViewerSettings];
 }
 
+- (void)setAnnotationToolbarItemEnabled:(NSString *)itemId enable:(BOOL)enable
+{
+    if ([self.documentViewController isKindOfClass:[PTDocumentController class]]) {
+        PTDocumentController *controller = (PTDocumentController *) self.documentViewController;
+        Class toolClass = [[self class] toolClassForKey:itemId];
+
+        if (toolClass != Nil) {
+            // default toolbar button
+            for (PTToolGroup *toolGroup in controller.toolGroupManager.groups) {
+                for (UIBarButtonItem *item in toolGroup.barButtonItems) {
+                    if ([item isKindOfClass:[PTToolBarButtonItem class]]) {
+                        PTToolBarButtonItem *toolItem = (PTToolBarButtonItem *)item;
+                        
+                        if ([toolItem.toolClass isEqual:toolClass]) {
+                            toolItem.enabled = enable;
+                        }
+                    }
+                }
+            }
+        } else {
+            // custom toolbar button
+            NSNumber *const itemTag = _annotationToolbarItemKeyMap[itemId];
+            
+            if (itemTag) {
+                for (PTToolGroup *toolGroup in controller.toolGroupManager.groups) {
+                    for (UIBarButtonItem *item in toolGroup.barButtonItems) {
+                        if (item.tag == itemTag.integerValue) {
+                            item.enabled = enable;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 #pragma mark - Viewer options
 
 -(void)setNightModeEnabled:(BOOL)nightModeEnabled
@@ -2574,10 +2610,10 @@ NS_ASSUME_NONNULL_END
             
             UIImage * const toolbarItemIcon = [self imageForImageName:toolbarItemIconName];
             // NOTE: Use the image-based initializer to avoid showing the title (safe to set the title afterwards though).
-            PTSelectableBarButtonItem * const item = [[PTSelectableBarButtonItem alloc] initWithImage:toolbarItemIcon
-                                                                                                style:UIBarButtonItemStylePlain
-                                                                                               target:self
-                                                                                               action:@selector(customToolGroupToolbarItemPressed:)];
+            PTSelectableBarButtonItem * const item = [[PTSelectableBarButtonItem alloc]                                                                 initWithImage:toolbarItemIcon
+                                                      style:UIBarButtonItemStylePlain
+                                                      target:self
+                                                      action:@selector(customToolGroupToolbarItemPressed:)];
             item.title = toolbarItemName;
             
             NSAssert(toolbarItemId != nil, @"Expected a toolbar item id");

--- a/ios/RNTPTDocumentViewManager.h
+++ b/ios/RNTPTDocumentViewManager.h
@@ -65,6 +65,8 @@
 
 - (NSString *)getCustomDataForAnnotationForDocumentViewTag:(NSNumber *) tag annotationId:(NSString *)annotationId  pageNumber:(NSInteger)pageNumber key:(NSString *)key;
 
+- (void)setAnnotationToolbarItemEnabled:(NSNumber *)tag itemId:(NSString *)itemId enable:(BOOL)enable;
+
 - (NSDictionary<NSString *, NSNumber *> *)getPageCropBoxForDocumentViewTag:(NSNumber *)tag pageNumber:(NSInteger)pageNumber;
 
 - (NSMutableArray<NSDictionary *> *)getAllFieldsForDocumentViewTag:(NSNumber *)tag pageNumber:(NSInteger)pageNumber;

--- a/ios/RNTPTDocumentViewManager.m
+++ b/ios/RNTPTDocumentViewManager.m
@@ -1253,6 +1253,15 @@ RCT_CUSTOM_VIEW_PROPERTY(defaultEraserType, NSString, RNTPTDocumentView)
     }
 }
 
+- (void)setAnnotationToolbarItemEnabled:(NSNumber *)tag itemId:(NSString *)itemId enable:(BOOL)enable
+{
+    RNTPTDocumentView *documentView = self.documentViews[tag];
+    if (documentView) {
+        return [documentView setAnnotationToolbarItemEnabled:itemId enable:enable];
+    } else {
+        @throw [NSException exceptionWithName:NSInvalidArgumentException reason:@"Unable to find DocumentView for tag" userInfo:nil];
+    }
+}
 
 - (NSDictionary<NSString *, NSNumber *> *)getPageCropBoxForDocumentViewTag:(NSNumber *)tag pageNumber:(NSInteger)pageNumber
 {

--- a/ios/RNTPTDocumentViewModule.m
+++ b/ios/RNTPTDocumentViewModule.m
@@ -488,6 +488,22 @@ RCT_REMAP_METHOD(getCustomDataForAnnotation,
     }
 }
 
+RCT_REMAP_METHOD(setAnnotationToolbarItemEnabled,
+                 setAnnotationToolbarItemEnabledForDocumentViewTag:(nonnull NSNumber *)tag
+                 itemId:(NSString *)itemId
+                 enable:(BOOL)enable
+                 resolver:(RCTPromiseResolveBlock)resolve
+                 rejector:(RCTPromiseRejectBlock)reject)
+{
+    @try {
+        [[self documentViewManager] setAnnotationToolbarItemEnabled:tag itemId:itemId enable:enable];
+        resolve(nil);
+    }
+    @catch (NSException *exception) {
+        reject(@"set_annotation_toolbar_item_enabled", @"Failed to set item enabled/disabled", [self errorFromException:exception]);
+    }
+}
+
 RCT_REMAP_METHOD(getPageCropBox,
                  getPageCropBoxForDocumentViewTag: (nonnull NSNumber *)tag
                  pageNumber:(NSInteger)pageNumber

--- a/lib/src/DocumentView/DocumentView.js
+++ b/lib/src/DocumentView/DocumentView.js
@@ -648,6 +648,13 @@ export class DocumentView extends PureComponent {
         }
         return Promise.resolve();
     };
+    setAnnotationToolbarItemEnabled = (id, enable) => {
+        const tag = findNodeHandle(this._viewerRef);
+        if (tag != null) {
+            return DocumentViewManager.setAnnotationToolbarItemEnabled(id, enable);
+        }
+        return Promise.resolve();
+    };
     getPageCropBox = (pageNumber) => {
         const tag = findNodeHandle(this._viewerRef);
         if (tag != null) {

--- a/lib/src/DocumentView/DocumentView.js
+++ b/lib/src/DocumentView/DocumentView.js
@@ -648,10 +648,10 @@ export class DocumentView extends PureComponent {
         }
         return Promise.resolve();
     };
-    setAnnotationToolbarItemEnabled = (id, enable) => {
+    setAnnotationToolbarItemEnabled = (itemId, enable) => {
         const tag = findNodeHandle(this._viewerRef);
         if (tag != null) {
-            return DocumentViewManager.setAnnotationToolbarItemEnabled(id, enable);
+            return DocumentViewManager.setAnnotationToolbarItemEnabled(itemId, enable);
         }
         return Promise.resolve();
     };

--- a/lib/src/DocumentView/DocumentView.js
+++ b/lib/src/DocumentView/DocumentView.js
@@ -651,7 +651,7 @@ export class DocumentView extends PureComponent {
     setAnnotationToolbarItemEnabled = (itemId, enable) => {
         const tag = findNodeHandle(this._viewerRef);
         if (tag != null) {
-            return DocumentViewManager.setAnnotationToolbarItemEnabled(itemId, enable);
+            return DocumentViewManager.setAnnotationToolbarItemEnabled(tag, itemId, enable);
         }
         return Promise.resolve();
     };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "3.0.2-beta.108",
+  "version": "3.0.2-beta.109",
   "description": "React Native Pdftron",
   "main": "./lib/index.js",
   "typings": "index.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "3.0.2-beta.99",
+  "version": "3.0.2-beta.100",
   "description": "React Native Pdftron",
   "main": "./lib/index.js",
   "typings": "index.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "3.0.2-beta.98",
+  "version": "3.0.2-beta.99",
   "description": "React Native Pdftron",
   "main": "./lib/index.js",
   "typings": "index.ts",

--- a/src/DocumentView/DocumentView.tsx
+++ b/src/DocumentView/DocumentView.tsx
@@ -685,7 +685,7 @@ export class DocumentView extends PureComponent<DocumentViewProps, any> {
     return Promise.resolve();
   }
 
-  setAnnotationToolbarItemEnabled = (itemId: number, enable: boolean) : Promise<void> => {
+  setAnnotationToolbarItemEnabled = (itemId: string, enable: boolean) : Promise<void> => {
     const tag = findNodeHandle(this._viewerRef);
     if (tag != null) {
       return DocumentViewManager.setAnnotationToolbarItemEnabled(itemId, enable);

--- a/src/DocumentView/DocumentView.tsx
+++ b/src/DocumentView/DocumentView.tsx
@@ -685,6 +685,14 @@ export class DocumentView extends PureComponent<DocumentViewProps, any> {
     return Promise.resolve();
   }
 
+  setAnnotationToolbarItemEnabled = (itemId: number, enable: boolean) : Promise<void> => {
+    const tag = findNodeHandle(this._viewerRef);
+    if (tag != null) {
+      return DocumentViewManager.setAnnotationToolbarItemEnabled(itemId, enable);
+    }
+    return Promise.resolve();
+  }
+
   getPageCropBox = (pageNumber: number): Promise<void | AnnotOptions.CropBox> => {
     const tag = findNodeHandle(this._viewerRef);
     if (tag != null) {

--- a/src/DocumentView/DocumentView.tsx
+++ b/src/DocumentView/DocumentView.tsx
@@ -688,7 +688,7 @@ export class DocumentView extends PureComponent<DocumentViewProps, any> {
   setAnnotationToolbarItemEnabled = (itemId: string, enable: boolean) : Promise<void> => {
     const tag = findNodeHandle(this._viewerRef);
     if (tag != null) {
-      return DocumentViewManager.setAnnotationToolbarItemEnabled(itemId, enable);
+      return DocumentViewManager.setAnnotationToolbarItemEnabled(tag, itemId, enable);
     }
     return Promise.resolve();
   }


### PR DESCRIPTION
https://linear.app/pdftron/issue/CPM-4/[support-30534]-method-api-to-enabledisable-annotation-toolbar-item

Some issues noticed on the native side.

Android: 
The toolbar buttons are being disabled using the `AnnotationToolbarComponent setItemEnabled` [method](https://www.pdftron.com/api/android/javadoc/reference/com/pdftron/pdf/widget/toolbar/component/AnnotationToolbarComponent.html#setItemEnabled(int,%20boolean)), but while the buttons appear disabled as they are greyed out the user is still able to click on the button and use its functionality.

iOS:
The buttons are being disabled by setting the `enabled` property of the `UIBarButtonItem` to false. Doing so properly disables the buttons as they don't receive events, but the appearance of the button remains the same as when they are enabled.