### PR TITLE
Use ViewPropTypes from deprecated-react-native-prop-types

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   ],
   "readmeFilename": "README.md",
   "peerDependencies": {
+    "deprecated-react-native-prop-types": "*",
     "react": "*",
     "react-native": "*",
     "prop-types": "*"

--- a/src/DocumentView/DocumentView.tsx
+++ b/src/DocumentView/DocumentView.tsx
@@ -2,12 +2,12 @@ import React, { PureComponent } from 'react';
 import PropTypes, { Requireable, Validator } from 'prop-types';
 import {
   requireNativeComponent,
-  ViewPropTypes,
   Platform,
   Alert,
   NativeModules,
   findNodeHandle,
 } from 'react-native';
+import { ViewPropTypes } from 'deprecated-react-native-prop-types';
 const { DocumentViewManager } = NativeModules;
 import { Config } from "../Config/Config";
 import * as AnnotOptions from "../AnnotOptions/AnnotOptions";

--- a/src/PDFViewCtrl/PDFViewCtrl.tsx
+++ b/src/PDFViewCtrl/PDFViewCtrl.tsx
@@ -2,9 +2,9 @@ import React, { PureComponent } from 'react';
 import PropTypes, { InferProps } from 'prop-types';
 import {
   requireNativeComponent,
-  ViewPropTypes,
   Platform
 } from 'react-native';
+import { ViewPropTypes } from 'deprecated-react-native-prop-types';
 
 const propTypes = {
   document: PropTypes.string.isRequired,

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,0 +1,1 @@
+declare module 'deprecated-react-native-prop-types';


### PR DESCRIPTION
Triggers a warning in React Native `0.68` and has been removed in current release `0.69`

`ViewPropTypes will be removed from React Native. Migrate to ViewPropTypes exported from 'deprecated-react-native-prop-types'.`

Edit: We're not using TypeScript but it appears that `InferProps` isn't playing nicely with the spread of `ViewPropTypes` anymore.