### PR TITLE
[Support-33786 | Android] Read only mode Android React Native fix

### DIFF
--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -436,9 +436,11 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
     public void setReadOnly(boolean readOnly) {
         mReadOnly = readOnly;
         if (readOnly) {
-            mBuilder = mBuilder.skipReadOnlyCheck(false).documentEditingEnabled(false);
+            mBuilder = mBuilder.skipReadOnlyCheck(false)
+                    .documentEditingEnabled(false);
         } else {
-            mBuilder = mBuilder.skipReadOnlyCheck(true).documentEditingEnabled(true);
+            mBuilder = mBuilder.skipReadOnlyCheck(true)
+                    .documentEditingEnabled(true);
         }
         if (getToolManager() != null) {
             getToolManager().setSkipReadOnlyCheck(false);
@@ -3573,7 +3575,7 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
 
     public void setAnnotationToolbarItemEnabled(String itemId, boolean enable) {
         if (mPdfViewCtrlTabHostFragment != null &&
-            mPdfViewCtrlTabHostFragment instanceof RNPdfViewCtrlTabHostFragment) {
+                mPdfViewCtrlTabHostFragment instanceof RNPdfViewCtrlTabHostFragment) {
             int buttonId = convStringToButtonId(itemId);
             if (buttonId == 0) {
                 for (int i = 0; i < mToolIdMap.size(); i++) {

--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -436,9 +436,9 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
     public void setReadOnly(boolean readOnly) {
         mReadOnly = readOnly;
         if (readOnly) {
-            mBuilder = mBuilder.skipReadOnlyCheck(false);
+            mBuilder = mBuilder.skipReadOnlyCheck(false).documentEditingEnabled(false);
         } else {
-            mBuilder = mBuilder.skipReadOnlyCheck(true);
+            mBuilder = mBuilder.skipReadOnlyCheck(true).documentEditingEnabled(true);
         }
         if (getToolManager() != null) {
             getToolManager().setSkipReadOnlyCheck(false);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "3.0.2-beta.121",
+  "version": "3.0.2-beta.122",
   "description": "React Native Pdftron",
   "main": "./lib/index.js",
   "typings": "index.ts",


### PR DESCRIPTION
Fixes case where users were editing documents when in Read Only mode and setting to reading mode in Android RN app

Closes NSDK-202

Steps to reproduce:
1. in apps.js, set readOnly to true
2. open app
3. open viewing mode menu and set to reading mode from single page
4. highlight over text in document to see pop up menu
5. should see no text annotation edits (strikethrough, outline, highlight, etc.)