### PR TITLE
[Support-32057] ClearSavedViewerState method not working with XOD files

### DIFF
--- a/android/src/main/java/com/pdftron/reactnative/modules/RNPdftronModule.java
+++ b/android/src/main/java/com/pdftron/reactnative/modules/RNPdftronModule.java
@@ -223,6 +223,7 @@ public class RNPdftronModule extends ReactContextBaseJavaModule {
             PdfViewCtrlTabsManager.getInstance().cleanup();
             PdfViewCtrlTabsManager.getInstance().clearAllPdfViewCtrlTabInfo(getReactApplicationContext());
             PdfViewCtrlSettingsManager.setOpenUrlAsyncCache(getReactApplicationContext(), "");
+            PdfViewCtrlSettingsManager.setOpenUrlPageStateAsyncCache(getReactApplicationContext(), "");
             promise.resolve(null);
         } catch (Exception e) {
             promise.reject(e);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "3.0.2-beta.122",
+  "version": "3.0.2-beta.123",
   "description": "React Native Pdftron",
   "main": "./lib/index.js",
   "typings": "index.ts",


### PR DESCRIPTION
Added setOpenUrlPageStateAsyncCache to clearSavedViewerState

Closes NSDK-190