### PR TITLE
[Support-34290] Disable annotating on Reader Mode when read-only (iOS)

### DIFF
--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -2915,13 +2915,15 @@ NS_ASSUME_NONNULL_END
     if( [documentViewController.document HasDownloader] )
     {
         if( ![toolManager isReadonly] )
-         {
+        {
             toolManager.readonly = self.readOnly;
+            toolManager.annotateOnReflowEnabled = !self.readOnly;
         }
     }
     else
     {
         toolManager.readonly = self.readOnly;
+        toolManager.annotateOnReflowEnabled = !self.readOnly;
     }
     
     documentViewController.thumbnailsViewController.editingEnabled = !self.readOnly;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "3.0.2-beta.124",
+  "version": "3.0.2-beta.125",
   "description": "React Native Pdftron",
   "main": "./lib/index.js",
   "typings": "index.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "3.0.2-beta.125",
+  "version": "3.0.2-beta.126",
   "description": "React Native Pdftron",
   "main": "./lib/index.js",
   "typings": "index.ts",


### PR DESCRIPTION
Closes [NSDK-226](https://linear.app/pdftron/issue/NSDK-226/[support-34290]-add-readonly-config-for-ios-in-react-native)

Fixed issue where users were still able to add annotations in Reader mode when viewer was in read-only

STR:
1. In `App.js`, set `readOnly={true}`
2. Enter Reading Mode
3. Long press on text to bring up context
4. Should not have any options to add annotations (highlight, strikethrough, etc.)