### PR TITLE
[Support-29040] Set signature colors

### DIFF
--- a/API.md
+++ b/API.md
@@ -1941,6 +1941,23 @@ Defines whether to show the option to pick images in the signature dialog.
 />
 ```
 
+#### signatureColors
+array of objects containing keys `red`, `green`, and `blue`, optional
+
+The colors that the user can select to create a signature. Maximum of three colors. 
+
+On Android, when this config is set, the user will not be able to customize each color shown.
+Defaults to black, blue, green for Android, and black, blue, red for iOS.
+
+```js
+<DocumentView
+  signatureColors={[
+    { 'red': 255, 'green': 0, 'blue': 0 },
+    { 'red':   0, 'green': 0, 'blue': 0 },
+  ]}
+/>
+```
+
 #### onSavedSignaturesChanged
 function, optional
 

--- a/android/src/main/java/com/pdftron/reactnative/viewmanagers/DocumentViewViewManager.java
+++ b/android/src/main/java/com/pdftron/reactnative/viewmanagers/DocumentViewViewManager.java
@@ -532,6 +532,10 @@ public class DocumentViewViewManager extends ViewGroupManager<DocumentView> {
     }
 
     // Hygen Generated Props
+    @ReactProp(name = "signatureColors")
+    public void setSignatureColors(DocumentView documentView, @NonNull ReadableArray signatureColors) {
+        documentView.setSignatureColors(signatureColors);
+    }
 
     @ReactProp(name = "overrideToolbarButtonBehavior")
     public void setOverrideToolbarButtonBehavior(DocumentView documentView, @NonNull ReadableArray items) {

--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -3,6 +3,7 @@ package com.pdftron.reactnative.views;
 import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
+import android.graphics.Color;
 import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
@@ -749,6 +750,25 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
     }
 
     // Hygen Generated Props
+    public void setSignatureColors(@NonNull ReadableArray signatureColors) {
+        int[] result = new int[signatureColors.size()];
+
+        for (int i = 0; i < signatureColors.size(); i++) {
+            ReadableType type = signatureColors.getType(i);
+
+            if (type == ReadableType.Map) {
+                ReadableMap map = signatureColors.getMap(i);
+
+                int red = map.getInt(COLOR_RED);
+                int green = map.getInt(COLOR_GREEN);
+                int blue = map.getInt(COLOR_BLUE);
+
+                result[i] = Color.rgb(red, green, blue);
+            }
+        }
+
+        mToolManagerBuilder = mToolManagerBuilder.setSignatureColors(result);
+    }
 
     public void setAnnotationToolbars(ReadableArray toolbars) {
         if (toolbars.size() == 0) {

--- a/ios/RNTPTDocumentView.h
+++ b/ios/RNTPTDocumentView.h
@@ -418,6 +418,7 @@ static NSString * const PTSignaturesManager_signatureDirectory = @"PTSignaturesM
 @property (nonatomic, assign) BOOL enableAntialiasing;
 
 // Hygen Generated Props
+@property (nonatomic, copy, nullable) NSArray<NSDictionary *> *signatureColors;
 
 @property (nonatomic, copy, nullable) NSString *password;
 @property (nonatomic, copy, nullable) NSString *document;

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -2347,6 +2347,24 @@ NS_ASSUME_NONNULL_END
     // Enable/disable restoring state (last read page).
     [NSUserDefaults.standardUserDefaults setBool:self.saveStateEnabled
                                           forKey:@"gotoLastPage"];
+    
+    // Signature colors
+    if (self.signatureColors) {
+        NSMutableArray<UIColor *> *colorArray = [[NSMutableArray alloc] init];
+
+        for (NSDictionary *color in self.signatureColors) {
+            NSNumber *red = color[PTColorRedKey];
+            NSNumber *green = color[PTColorGreenKey];
+            NSNumber *blue = color[PTColorBlueKey];
+
+            [colorArray addObject:[UIColor colorWithRed:[red doubleValue] / 255
+                                                  green:[green doubleValue] / 255
+                                                   blue:[blue doubleValue] / 255
+                                                  alpha:1.0]];
+        }
+
+        toolManager.signatureAnnotationOptions.signatureColors = [colorArray copy];
+    }
 }
 
 - (void)applyLeadingNavButton
@@ -6061,6 +6079,13 @@ NS_ASSUME_NONNULL_END
 }
 
 #pragma mark - Hygen Generated Props/Methods
+
+- (void)setSignatureColors:(NSArray *)signatureColors
+{
+    _signatureColors = [signatureColors copy];
+    
+    [self applyViewerSettings];
+}
 
 @end
 

--- a/ios/RNTPTDocumentViewManager.m
+++ b/ios/RNTPTDocumentViewManager.m
@@ -658,6 +658,12 @@ RCT_CUSTOM_VIEW_PROPERTY(overrideToolbarButtonBehavior, NSArray, RNTPTDocumentVi
 }
 
 // Hygen Generated Props
+RCT_CUSTOM_VIEW_PROPERTY(signatureColors, NSArray, RNTPTDocumentView)
+{
+    if (json) {
+        view.signatureColors = [RCTConvert NSArray:json];
+    }
+}
 
 
 - (UIView *)view

--- a/lib/src/DocumentView/DocumentView.js
+++ b/lib/src/DocumentView/DocumentView.js
@@ -156,6 +156,11 @@ const propTypes = {
     overrideToolbarButtonBehavior: arrayOf(Config.Buttons),
     onToolbarButtonPress: func(),
     // Hygen Generated Props
+    signatureColors: PropTypes.arrayOf(PropTypes.exact({
+        red: PropTypes.number.isRequired,
+        green: PropTypes.number.isRequired,
+        blue: PropTypes.number.isRequired,
+    })),
     onCurrentToolbarChanged: func(),
     ...ViewPropTypes,
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "3.0.2-beta.124",
+  "version": "3.0.2-beta.125",
   "description": "React Native Pdftron",
   "main": "./lib/index.js",
   "typings": "index.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "3.0.2-beta.126",
+  "version": "3.0.2-beta.127",
   "description": "React Native Pdftron",
   "main": "./lib/index.js",
   "typings": "index.ts",

--- a/src/DocumentView/DocumentView.tsx
+++ b/src/DocumentView/DocumentView.tsx
@@ -165,6 +165,11 @@ const propTypes = {
   onToolbarButtonPress: func<(event: {id: string}) => void>(),
 
   // Hygen Generated Props
+  signatureColors: PropTypes.arrayOf(PropTypes.exact({
+    red: PropTypes.number.isRequired,
+    green: PropTypes.number.isRequired,
+    blue: PropTypes.number.isRequired,
+  })),
   onCurrentToolbarChanged: func<(event: { toolbar: string }) => void>(),
 
   ...ViewPropTypes,


### PR DESCRIPTION
Closes [NSDK-237](https://linear.app/pdftron/issue/NSDK-237/[support-29040]-add-api-to-set-signature-colours-react-native)

Adds API that allows users to specify a list of colors that the user can select when creating a signature.

Testing:
1. In `App.js`, set the `signatureColors` prop. For example: 
```js
<DocumentView
  ...
  signatureColors={[
    { 'red': 255, 'green': 0, 'blue': 0 },
    { 'red':   0, 'green': 0, 'blue': 0 },
  ]}
/>
```
2. Open signature creation dialog. Should only display specified colors