### PR TITLE
[Support-33786] Add API to disable Reading Mode Settings button

### DIFF
--- a/API.md
+++ b/API.md
@@ -639,7 +639,8 @@ Defines view mode items to be hidden in the view mode dialog.
   hideViewModeItems={[
     Config.ViewModePickerItem.Crop,
     Config.ViewModePickerItem.Rotation,
-    Config.ViewModePickerItem.ColorMode
+    Config.ViewModePickerItem.ColorMode,
+    Config.ViewModePickerItem.ReaderModeSettings,
   ]}
 />
 ```

--- a/android/src/main/java/com/pdftron/reactnative/utils/Constants.java
+++ b/android/src/main/java/com/pdftron/reactnative/utils/Constants.java
@@ -278,6 +278,7 @@ public final class Constants {
     public static final String VIEW_MODE_CROP = "viewModeCrop";
     public static final String VIEW_MODE_ROTATION = "viewModeRotation";
     public static final String VIEW_MODE_COLORMODE = "viewModeColorMode";
+    public static final String VIEW_MODE_READER_MODE_SETTINGS = "viewModeReaderModeSettings";
 
     public static final String PREV_PAGE_KEY = "previousPageNumber";
     public static final String PAGE_CURRENT_KEY = "pageNumber";

--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -922,6 +922,8 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
                 mViewModePickerItems.add(ViewModePickerDialogFragment.ViewModePickerItems.ITEM_ID_ROTATION);
             } else if (VIEW_MODE_COLORMODE.equals(mode)) {
                 mViewModePickerItems.add(ViewModePickerDialogFragment.ViewModePickerItems.ITEM_ID_COLORMODE);
+            } else if (VIEW_MODE_READER_MODE_SETTINGS.equals(mode)) {
+                mViewModePickerItems.add(ViewModePickerDialogFragment.ViewModePickerItems.ITEM_ID_READING_MODE);
             }
         }
     }

--- a/ios/RNTPTDocumentView.h
+++ b/ios/RNTPTDocumentView.h
@@ -127,7 +127,7 @@ static NSString * const PTFacingCoverContinuousLayoutModeKey = @"FacingCoverCont
 static NSString * const PTViewModeCropKey = @"viewModeCrop";
 static NSString * const PTViewModeRotationKey = @"viewModeRotation";
 static NSString * const PTViewModeColorModeKey = @"viewModeColorMode";
-
+static NSString * const PTViewModeReaderModeSettingsKey = @"viewModeReaderModeSettings";
 
 static NSString * const PTThumbnailsViewInsertPagesKey = @"thumbnailsInsertPages";
 static NSString * const PTThumbnailsViewExportPagesKey = @"thumbnailsExportPages";

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -2237,6 +2237,9 @@ NS_ASSUME_NONNULL_END
             documentViewController.settingsViewController.pageRotationHidden = YES;
         } else if ([viewModeItemString isEqualToString:PTViewModeCropKey]) {
             documentViewController.settingsViewController.cropPagesHidden = YES;
+        } else if ([viewModeItemString isEqualToString:PTViewModeReaderModeSettingsKey]) {
+            documentViewController.automaticallyHidesReflowSettingsButton = NO;
+            documentViewController.reflowSettingsButtonHidden = YES;
         }
     }
 

--- a/lib/src/Config/Config.js
+++ b/lib/src/Config/Config.js
@@ -249,6 +249,7 @@ export const Config = {
         Crop: "viewModeCrop",
         Rotation: "viewModeRotation",
         ColorMode: "viewModeColorMode",
+        ReaderModeSettings: "viewModeReaderModeSettings",
     },
     // ZoomLimitMode defines the limit mode for zoom in the current document viewer
     ZoomLimitMode: {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "3.0.2-beta.125",
+  "version": "3.0.2-beta.127",
   "description": "React Native Pdftron",
   "main": "./lib/index.js",
   "typings": "index.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "3.0.2-beta.127",
+  "version": "3.0.2-beta.128",
   "description": "React Native Pdftron",
   "main": "./lib/index.js",
   "typings": "index.ts",

--- a/src/Config/Config.ts
+++ b/src/Config/Config.ts
@@ -176,7 +176,7 @@ export const Config = {
     share: 'share',
     read: 'read',
   },
-  
+
   // Actions define potentially overridable action to the viewer
   Actions: {
     linkPress: 'linkPress',
@@ -265,12 +265,13 @@ export const Config = {
     Canvas: "canvas",
     Page: "page",
   },
-  
+
   // ViewModePickerItem defines view mode items in the view mode dialog
   ViewModePickerItem: {
     Crop: "viewModeCrop",
     Rotation: "viewModeRotation",
     ColorMode: "viewModeColorMode",
+    ReaderModeSettings: "viewModeReaderModeSettings",
   },
 
   // ZoomLimitMode defines the limit mode for zoom in the current document viewer
@@ -323,24 +324,24 @@ export const Config = {
 
 /**
  * A generic used to create the custom types defined in the module below.
- * 
+ *
  * The variable `T` represents the type information being passed into the generic.
  * This generic accepts type information about the `Config` object above. We pass this
  * information in using `typeof Config.*`, * is any object nested in the `Config` object.
- * 
- * `keyof T` creates a union of the object's keys e.g 
+ *
+ * `keyof T` creates a union of the object's keys e.g
  * `keyof typeof Config.ReflowOrientation == 'Horizonal' | 'Vertical'`
- * 
+ *
  * `T[]` is the indexed access type and takes the union produced by a `keyof T` and outputs
  * a union of value types corresponding to those keys, e.g.
  * `ValueOf<typeof Config.ReflowOrientation> == "horizontal" | "vertical"`
- * 
- * The above union is made up of string literal types because the `as const` operator sets the 
+ *
+ * The above union is made up of string literal types because the `as const` operator sets the
  * properties of the `Config` object to have literal types.
- * 
+ *
  * You can learn more about these special operators here:
  * - {@link https://www.typescriptlang.org/docs/handbook/2/typeof-types.html Typeof}
- * - {@link https://www.typescriptlang.org/docs/handbook/2/keyof-types.html Keyof} 
+ * - {@link https://www.typescriptlang.org/docs/handbook/2/keyof-types.html Keyof}
  * - {@link https://www.typescriptlang.org/docs/handbook/2/indexed-access-types.html Index Acess Types}
  * - {@link https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-4.html#const-assertions Const Assertions}
  */
@@ -348,7 +349,7 @@ type ValueOf<T> = T[keyof T];
 
 /**
  * A module containing custom types formed from the constants in the Config object.
- * 
+ *
  * These types are used for props such as `disabledElements` and methods such as `exportAsImage`
  */
 export module Config {
@@ -373,7 +374,7 @@ export module Config {
   export type ColorPostProcessMode = ValueOf<typeof Config.ColorPostProcessMode>;
   export type ReflowOrientation = ValueOf<typeof Config.ReflowOrientation>;
   export type ExportFormat = ValueOf<typeof Config.ExportFormat>;
-  export type AnnotationManagerEditMode = ValueOf<typeof Config.AnnotationManagerEditMode>; 
+  export type AnnotationManagerEditMode = ValueOf<typeof Config.AnnotationManagerEditMode>;
   export type AnnotationManagerUndoMode = ValueOf<typeof Config.AnnotationManagerUndoMode>;
   export type CustomToolbarKey = {
     id: string;


### PR DESCRIPTION
Closes [NSDK-201](https://linear.app/pdftron/issue/NSDK-201/[support-33786]-add-api-to-disable-reading-mode-settings-button)

Adds the Reader Mode Settings button in `Config.ViewModePickerItem` so users can hide the button using the `hideViewModeItems` prop

Testing:
1. In `App.js`, set the `hideViewModeItems` prop:
```js
<DocumentView
  ...
  hideViewModeItems={[
    Config.ViewModePickerItem.ReaderModeSettings,
  ]}
/>
```
2. Run the app and change view mode to reader mode. Should not be able to see the reader mode settings button