### PR TITLE
Add API support for disabling count tool

### DIFF
--- a/android/src/main/java/com/pdftron/reactnative/utils/Constants.java
+++ b/android/src/main/java/com/pdftron/reactnative/utils/Constants.java
@@ -89,7 +89,6 @@ public final class Constants {
     public static final String TOOL_BUTTON_EDIT = "editToolButton";
     public static final String TOOL_BUTTON_ADD_PAGE = "addPageButton";
     public static final String TOOL_BUTTON_INSERT_PAGE = "insertPageButton";
-    public static final String TOOL_BUTTON_COUNT = "countToolButton";
 
     // TOOLS
     public static final String TOOL_ANNOTATION_CREATE_FREE_HAND = "AnnotationCreateFreeHand";

--- a/android/src/main/java/com/pdftron/reactnative/utils/Constants.java
+++ b/android/src/main/java/com/pdftron/reactnative/utils/Constants.java
@@ -89,6 +89,7 @@ public final class Constants {
     public static final String TOOL_BUTTON_EDIT = "editToolButton";
     public static final String TOOL_BUTTON_ADD_PAGE = "addPageButton";
     public static final String TOOL_BUTTON_INSERT_PAGE = "insertPageButton";
+    public static final String TOOL_BUTTON_COUNT = "countToolButton";
 
     // TOOLS
     public static final String TOOL_ANNOTATION_CREATE_FREE_HAND = "AnnotationCreateFreeHand";
@@ -137,6 +138,7 @@ public final class Constants {
     public static final String TOOL_ANNOTATION_CREATE_FREE_SPACING_TEXT = "AnnotationCreateFreeSpacingText";
     public static final String TOOL_INSERT_PAGE = "InsertPage";
     public static final String TOOL_FORM_FILL = "FormFill";
+    public static final String TOOL_COUNT_TOOL = "AnnotationCountTool";
 
     // Field types
     public static final String FIELD_TYPE_UNKNOWN = "unknown";

--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -1675,8 +1675,6 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
             buttonId = DefaultToolbars.ButtonId.REDO.value();
         } else if (BUTTON_EDIT_MENU.equals(item)) {
             buttonId = DefaultToolbars.ButtonId.CUSTOMIZE.value();
-        } else if (TOOL_BUTTON_COUNT.equals(item)) {
-            buttonId = DefaultToolbars.ButtonId.COUNT_TOOL.value();
         }
         return buttonId;
     }
@@ -1836,8 +1834,6 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
             buttonType = ToolbarButtonType.REDO;
         } else if (BUTTON_EDIT_MENU.equals(item)) {
             buttonType = ToolbarButtonType.EDIT_TOOLBAR;
-        } else if (TOOL_BUTTON_COUNT.equals(item)) {
-            buttonType = ToolbarButtonType.COUNT_MEASUREMENT;
         }
         return buttonType;
     }

--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -1270,6 +1270,8 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
             annotType = Annot.e_Widget;
         } else if (TOOL_ANNOTATION_CREATE_FREE_HIGHLIGHTER.equals(item)) {
             annotType = AnnotStyle.CUSTOM_ANNOT_TYPE_FREE_HIGHLIGHTER;
+        } else if (TOOL_COUNT_TOOL.equals(item)) {
+            annotType = AnnotStyle.CUSTOM_ANNOT_TYPE_COUNT_MEASUREMENT;
         }
         return annotType;
     }
@@ -1445,6 +1447,8 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
             mode = ToolManager.ToolMode.SMART_PEN_INK;
         } else if (TOOL_FORM_FILL.equals(item)) {
             mode = ToolManager.ToolMode.FORM_FILL;
+        } else if (TOOL_COUNT_TOOL.equals(item)) {
+            mode = ToolManager.ToolMode.COUNT_MEASUREMENT;
         }
         return mode;
     }
@@ -1583,6 +1587,9 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
             case FREE_TEXT_DATE_CREATE:
                 toolModeString = TOOL_ANNOTATION_CREATE_FREE_TEXT_DATE;
                 break;
+            case COUNT_MEASUREMENT:
+                toolModeString = TOOL_COUNT_TOOL;
+                break;
         }
 
         return toolModeString;
@@ -1668,6 +1675,8 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
             buttonId = DefaultToolbars.ButtonId.REDO.value();
         } else if (BUTTON_EDIT_MENU.equals(item)) {
             buttonId = DefaultToolbars.ButtonId.CUSTOMIZE.value();
+        } else if (TOOL_BUTTON_COUNT.equals(item)) {
+            buttonId = DefaultToolbars.ButtonId.COUNT_TOOL.value();
         }
         return buttonId;
     }
@@ -1827,6 +1836,8 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
             buttonType = ToolbarButtonType.REDO;
         } else if (BUTTON_EDIT_MENU.equals(item)) {
             buttonType = ToolbarButtonType.EDIT_TOOLBAR;
+        } else if (TOOL_BUTTON_COUNT.equals(item)) {
+            buttonType = ToolbarButtonType.COUNT_MEASUREMENT;
         }
         return buttonType;
     }

--- a/ios/RNTPTDocumentView.h
+++ b/ios/RNTPTDocumentView.h
@@ -56,7 +56,6 @@ static NSString * const PTInsertFromImageButton = @"insertFromImageButton";
 static NSString * const PTInsertFromPhotoButton = @"insertFromPhotoButton";
 static NSString * const PTInsertFromDocumentButton = @"insertFromDocumentButton";
 static NSString * const PTInsertFromScannerButton = @"insertFromScannerButton";
-static NSString * const PTCountToolButton = @"countToolButton";
 
 static NSString * const PTAnnotationEditToolKey = @"AnnotationEdit";
 static NSString * const PTAnnotationCreateStickyToolKey = @"AnnotationCreateSticky";

--- a/ios/RNTPTDocumentView.h
+++ b/ios/RNTPTDocumentView.h
@@ -56,6 +56,7 @@ static NSString * const PTInsertFromImageButton = @"insertFromImageButton";
 static NSString * const PTInsertFromPhotoButton = @"insertFromPhotoButton";
 static NSString * const PTInsertFromDocumentButton = @"insertFromDocumentButton";
 static NSString * const PTInsertFromScannerButton = @"insertFromScannerButton";
+static NSString * const PTCountToolButton = @"countToolButton";
 
 static NSString * const PTAnnotationEditToolKey = @"AnnotationEdit";
 static NSString * const PTAnnotationCreateStickyToolKey = @"AnnotationCreateSticky";
@@ -83,6 +84,7 @@ static NSString * const PTAnnotationCreatePerimeterMeasurementToolKey = @"Annota
 static NSString * const PTAnnotationCreateAreaMeasurementToolKey = @"AnnotationCreateAreaMeasurement";
 static NSString * const PTPanToolKey = @"Pan";
 static NSString * const PTAnnotationEraserToolKey = @"AnnotationEraserTool";
+static NSString * const PTAnnotationCountToolKey = @"AnnotationCountTool";
 static NSString * const PTAnnotationCreateSoundToolKey = @"AnnotationCreateSound";
 static NSString * const PTPencilKitDrawingToolKey = @"PencilKitDrawing";
 static NSString * const PTAnnotationCreateFreeHighlighterToolKey = @"AnnotationCreateFreeHighlighter";

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -966,6 +966,9 @@ NS_ASSUME_NONNULL_END
             else if([string isEqualToString:PTInsertFromDocumentButton]){
                 [addPagesItems removeObject:documentViewController.addPagesViewController.addDocumentPagesButtonItem];
             }
+            else if([string isEqualToString:PTCountToolButton]){
+                // TODO
+            }
         }
     }
     if([addPagesItems count] == 0){
@@ -1081,6 +1084,9 @@ NS_ASSUME_NONNULL_END
     }
     else if ( [toolMode isEqualToString:PTAnnotationEraserToolKey]) {
         toolClass = [PTEraser class];
+    }
+    else if ( [toolMode isEqualToString:PTAnnotationCountToolKey]) {
+        toolClass = [PTCountCreate class];
     }
     else if ( [toolMode isEqualToString:PTPencilKitDrawingToolKey]) {
         toolClass = [PTPencilDrawingCreate class];
@@ -5700,6 +5706,9 @@ NS_ASSUME_NONNULL_END
     else if ([key isEqualToString:PTAnnotationEraserToolKey]) {
         return [PTEraser class];
     }
+    else if ([key isEqualToString:PTAnnotationCountToolKey]) {
+        return [PTCountCreate class];
+    }
     else if ([key isEqualToString:PTAnnotationCreateFreeHighlighterToolKey]) {
         return [PTFreeHandHighlightCreate class];
     }
@@ -5823,6 +5832,9 @@ NS_ASSUME_NONNULL_END
     }
     else if (toolClass == [PTEraser class]) {
         return PTAnnotationEraserToolKey;
+    }
+    else if (toolClass == [PTCountCreate class]) {
+        return PTAnnotationCountToolKey;
     }
     else if (toolClass == [PTFreeHandHighlightCreate class]) {
         return PTAnnotationCreateFreeHighlighterToolKey;

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -966,9 +966,6 @@ NS_ASSUME_NONNULL_END
             else if([string isEqualToString:PTInsertFromDocumentButton]){
                 [addPagesItems removeObject:documentViewController.addPagesViewController.addDocumentPagesButtonItem];
             }
-            else if([string isEqualToString:PTCountToolButton]){
-                // TODO
-            }
         }
     }
     if([addPagesItems count] == 0){

--- a/lib/src/Config/Config.js
+++ b/lib/src/Config/Config.js
@@ -48,6 +48,7 @@ export const Config = {
         addPageButton: 'addPageButton',
         insertPageButton: 'insertPageButton',
         saveCroppedCopyButton: 'saveCroppedCopyButton',
+        countToolButton: 'countToolButton',
         // iOS only
         InsertBlankPage: "insertBlankPageButton",
         InsertFromImage: "insertFromImageButton",
@@ -67,6 +68,7 @@ export const Config = {
         multiSelect: 'MultiSelect',
         pan: 'Pan',
         annotationEraserTool: 'AnnotationEraserTool',
+        annotationCountTool: 'AnnotationCountTool',
         annotationCreateSticky: 'AnnotationCreateSticky',
         annotationCreateFreeHand: 'AnnotationCreateFreeHand',
         annotationCreateTextHighlight: 'AnnotationCreateTextHighlight',

--- a/lib/src/Config/Config.js
+++ b/lib/src/Config/Config.js
@@ -48,7 +48,6 @@ export const Config = {
         addPageButton: 'addPageButton',
         insertPageButton: 'insertPageButton',
         saveCroppedCopyButton: 'saveCroppedCopyButton',
-        countToolButton: 'countToolButton',
         // iOS only
         InsertBlankPage: "insertBlankPageButton",
         InsertFromImage: "insertFromImageButton",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "3.0.2-beta.133",
+  "version": "3.0.2-beta.134",
   "description": "React Native Pdftron",
   "main": "./lib/index.js",
   "typings": "index.ts",

--- a/src/Config/Config.ts
+++ b/src/Config/Config.ts
@@ -49,7 +49,7 @@ export const Config = {
     addPageButton: 'addPageButton',
     insertPageButton: 'insertPageButton',
     saveCroppedCopyButton: 'saveCroppedCopyButton',
-
+    countToolButton: 'countToolButton',
     // iOS only
     InsertBlankPage: "insertBlankPageButton",
     InsertFromImage: "insertFromImageButton",
@@ -71,6 +71,7 @@ export const Config = {
     multiSelect: 'MultiSelect',
     pan: 'Pan',
     annotationEraserTool: 'AnnotationEraserTool',
+    annotationCountTool: 'AnnotationCountTool',
     annotationCreateSticky: 'AnnotationCreateSticky',
     annotationCreateFreeHand: 'AnnotationCreateFreeHand',
     annotationCreateTextHighlight: 'AnnotationCreateTextHighlight',

--- a/src/Config/Config.ts
+++ b/src/Config/Config.ts
@@ -49,7 +49,6 @@ export const Config = {
     addPageButton: 'addPageButton',
     insertPageButton: 'insertPageButton',
     saveCroppedCopyButton: 'saveCroppedCopyButton',
-    countToolButton: 'countToolButton',
     // iOS only
     InsertBlankPage: "insertBlankPageButton",
     InsertFromImage: "insertFromImageButton",


### PR DESCRIPTION
added support to disable count measurement tool on iOS/Android

`disabledTools={[Config.Tools.annotationCreateLine, Config.Tools.annotationCreateRectangle, Config.Tools.annotationCountTool]}`

<img width="481" alt="image" src="https://user-images.githubusercontent.com/15988850/191581255-d9d53ad4-fcbd-4246-87e5-7cb07fb8f331.png">
