### PR TITLE
Update react-native project to use SDK version 9.3.2beta-05 snapshot

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -57,7 +57,7 @@ dependencies {
 
     implementation 'androidx.fragment:fragment:1.2.1'
 
-    implementation "com.pdftron:pdftron:9.3.2-beta02"
-    implementation "com.pdftron:tools:9.3.2-beta02"
-    implementation "com.pdftron:collab:9.3.2-beta02"
+    implementation "com.pdftron:pdftron:9.3.2-beta05"
+    implementation "com.pdftron:tools:9.3.2-beta05"
+    implementation "com.pdftron:collab:9.3.2-beta05"
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "3.0.2-beta.134",
+  "version": "3.0.2-beta.135",
   "description": "React Native Pdftron",
   "main": "./lib/index.js",
   "typings": "index.ts",


### PR DESCRIPTION
to fix crashing on changing annotation to view/vice-versa that adjusts the annotation tools toolbar