### PR TITLE
API Support for DateText annotation/tool type

### DIFF
--- a/ios/RNTPTDocumentView.h
+++ b/ios/RNTPTDocumentView.h
@@ -93,6 +93,7 @@ static NSString * const PTAnnotationCreateLinkToolKey = @"AnnotationCreateLink";
 static NSString * const PTAnnotationCreateRedactionTextToolKey = @"AnnotationCreateRedactionText";
 static NSString * const PTAnnotationCreateLinkTextToolKey = @"AnnotationCreateLinkText";
 static NSString * const PTAnnotationCreateSmartPenToolKey = @"AnnotationCreateSmartPen";
+static NSString * const PTAnnotationCreateFreeTextDateToolKey = @"AnnotationCreateFreeTextDate";
 static NSString * const PTFormCreateTextFieldToolKey = @"FormCreateTextField";
 static NSString * const PTFormCreateCheckboxFieldToolKey = @"FormCreateCheckboxField";
 static NSString * const PTFormCreateSignatureFieldToolKey = @"FormCreateSignatureField";

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -951,6 +951,9 @@ NS_ASSUME_NONNULL_END
             else if ([string isEqualToString:PTAnnotationCreateSmartPenToolKey]) {
                 toolManager.smartPenEnabled = value;
             }
+            else if ([string isEqualToString:PTAnnotationCreateFreeTextDateToolKey]) {
+                toolManager.dateTextAnnotationOptions.canCreate = value;
+            }
             else if ([string isEqualToString:PTFormFillToolKey]) {
                 toolManager.widgetAnnotationOptions.canEdit = value;
             }
@@ -5853,6 +5856,9 @@ NS_ASSUME_NONNULL_END
     }
     else if (toolClass == [PTSmartPen class]) {
         return PTAnnotationCreateSmartPenToolKey;
+    }
+    else if (toolClass == [PTDateTextCreate class]) {
+        return PTAnnotationCreateFreeTextDateToolKey;
     }
     else if (toolClass == [PTLinkCreate class]) {
        return PTAnnotationCreateLinkToolKey;

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -1128,6 +1128,9 @@ NS_ASSUME_NONNULL_END
     else if ( [toolMode isEqualToString:PTFormCreateListBoxFieldToolKey]) {
         toolClass = [PTListBoxCreate class];
     }
+    else if ( [toolMode isEqualToString:PTAnnotationCreateFreeTextDateToolKey]) {
+        toolClass = [PTDateTextCreate class];
+    }
     
     if (toolClass) {
         PTTool *tool = [self.currentDocumentViewController.toolManager changeTool:toolClass];

--- a/lib/src/Config/Config.js
+++ b/lib/src/Config/Config.js
@@ -96,6 +96,7 @@ export const Config = {
         annotationCreateRedactionText: 'AnnotationCreateRedactionText',
         annotationCreateFreeHighlighter: 'AnnotationCreateFreeHighlighter',
         annotationCreateSmartPen: 'AnnotationCreateSmartPen',
+        annotationCreateFreeTextDate: 'AnnotationCreateFreeTextDate',
         formCreateTextField: 'FormCreateTextField',
         formCreateCheckboxField: 'FormCreateCheckboxField',
         formCreateSignatureField: 'FormCreateSignatureField',

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "3.0.2-beta.137",
+  "version": "3.0.2-beta.138",
   "description": "React Native Pdftron",
   "main": "./lib/index.js",
   "typings": "index.ts",

--- a/src/Config/Config.ts
+++ b/src/Config/Config.ts
@@ -99,6 +99,7 @@ export const Config = {
     annotationCreateRedactionText: 'AnnotationCreateRedactionText',
     annotationCreateFreeHighlighter: 'AnnotationCreateFreeHighlighter',
     annotationCreateSmartPen: 'AnnotationCreateSmartPen',
+    annotationCreateFreeTextDate: 'AnnotationCreateFreeTextDate',
     formCreateTextField: 'FormCreateTextField',
     formCreateCheckboxField: 'FormCreateCheckboxField',
     formCreateSignatureField: 'FormCreateSignatureField',


### PR DESCRIPTION
added iOS api support for date text for onToolChanged API to read AnnotationCreateFreeTextDate instead of 'unknown tool'

android
![image](https://user-images.githubusercontent.com/15988850/195449678-6307ab86-5397-4831-8382-1d3827274ee3.png)
