### PR TITLE
API Support for setting stamp image programmatically given URL

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,6 @@
 
 buildscript {
+    ext.kotlinVersion = '1.6.0'
     repositories {
         google()
         mavenCentral()
@@ -7,6 +8,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.0'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
     }
 }
 
@@ -21,6 +23,9 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-android-extensions'
+apply plugin: 'kotlin-kapt'
 
 android {
     compileSdkVersion 31
@@ -36,6 +41,9 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
+    }
+    kotlinOptions {
+        jvmTarget = '1.8'
     }
     lintOptions {
         abortOnError false
@@ -60,4 +68,7 @@ dependencies {
     implementation "com.pdftron:pdftron:9.4.0"
     implementation "com.pdftron:tools:9.4.0"
     implementation "com.pdftron:collab:9.4.0"
+
+    implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.2.0'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0'
 }

--- a/android/src/main/java/com/pdftron/reactnative/modules/DocumentViewModule.java
+++ b/android/src/main/java/com/pdftron/reactnative/modules/DocumentViewModule.java
@@ -1457,6 +1457,22 @@ public class DocumentViewModule extends ReactContextBaseJavaModule implements Ac
 
     // Hygen Generated Methods
 
+    @ReactMethod
+    public void setStampImageData(final int tag, final String annotationId, final int pageNumber, final String stampImageDataUrl, final Promise promise) {
+        getReactApplicationContext().runOnUiQueueThread(new Runnable() {
+            @Override
+            public void run() {
+                try {
+                    mDocumentViewInstance.setStampImageData(tag, annotationId, pageNumber, stampImageDataUrl);
+                    promise.resolve(null);
+                } catch (Exception ex) {
+                    promise.reject(ex);
+                }
+            }
+        });
+    }
+
+
     @Override
     public void onActivityResult(Activity activity, int requestCode, int resultCode, Intent data) {
         mDocumentViewInstance.onActivityResult(requestCode, resultCode, data);

--- a/android/src/main/java/com/pdftron/reactnative/modules/DocumentViewModule.java
+++ b/android/src/main/java/com/pdftron/reactnative/modules/DocumentViewModule.java
@@ -1463,7 +1463,7 @@ public class DocumentViewModule extends ReactContextBaseJavaModule implements Ac
             @Override
             public void run() {
                 try {
-                    mDocumentViewInstance.setStampImageData(tag, annotationId, pageNumber, stampImageDataUrl);
+                    mDocumentViewInstance.setStampImageData(tag, annotationId, pageNumber, stampImageDataUrl, promise);
                     promise.resolve(null);
                 } catch (Exception ex) {
                     promise.reject(ex);

--- a/android/src/main/java/com/pdftron/reactnative/utils/DocumentViewUtils.kt
+++ b/android/src/main/java/com/pdftron/reactnative/utils/DocumentViewUtils.kt
@@ -1,0 +1,34 @@
+package com.pdftron.reactnative.utils
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import java.io.File
+import java.io.FileOutputStream
+import java.net.URL
+
+interface DownloadFileCallback {
+    fun downloadSuccess(path : String)
+
+    fun downloadFailed(e : Exception)
+}
+
+fun downloadFromURL(link : String, path: String, callback : DownloadFileCallback) {
+   CoroutineScope(Job() + Dispatchers.IO).launch {
+       try {
+           URL(link).openStream().use { input ->
+               FileOutputStream(File(path)).use { output ->
+                   input.copyTo(output)
+                   callback.downloadSuccess(path)
+               }
+           }
+
+       } catch (e : Exception) {
+           e.printStackTrace()
+           callback.downloadFailed(e)
+       }
+   }
+}
+
+

--- a/android/src/main/java/com/pdftron/reactnative/viewmanagers/DocumentViewViewManager.java
+++ b/android/src/main/java/com/pdftron/reactnative/viewmanagers/DocumentViewViewManager.java
@@ -7,6 +7,7 @@ import android.view.View;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.bridge.WritableArray;
@@ -1423,10 +1424,10 @@ public class DocumentViewViewManager extends ViewGroupManager<DocumentView> {
 
     // Hygen Generated Methods
 
-    public void setStampImageData(int tag, String annotationId, int pageNumber, String stampImageDataUrl) throws PDFNetException {
+    public void setStampImageData(int tag, String annotationId, int pageNumber, String stampImageDataUrl, Promise promise) throws PDFNetException {
         DocumentView documentView = mDocumentViews.get(tag);
         if (documentView != null) {
-            documentView.setStampImageData(annotationId, pageNumber, stampImageDataUrl);
+            documentView.setStampImageData(annotationId, pageNumber, stampImageDataUrl, promise);
         } else {
             throw new PDFNetException("", 0L, getName(), "setStampImageData", "Unable to find DocumentView.");
         }

--- a/android/src/main/java/com/pdftron/reactnative/viewmanagers/DocumentViewViewManager.java
+++ b/android/src/main/java/com/pdftron/reactnative/viewmanagers/DocumentViewViewManager.java
@@ -1423,7 +1423,6 @@ public class DocumentViewViewManager extends ViewGroupManager<DocumentView> {
     }
 
     // Hygen Generated Methods
-
     public void setStampImageData(int tag, String annotationId, int pageNumber, String stampImageDataUrl, Promise promise) throws PDFNetException {
         DocumentView documentView = mDocumentViews.get(tag);
         if (documentView != null) {

--- a/android/src/main/java/com/pdftron/reactnative/viewmanagers/DocumentViewViewManager.java
+++ b/android/src/main/java/com/pdftron/reactnative/viewmanagers/DocumentViewViewManager.java
@@ -1423,6 +1423,15 @@ public class DocumentViewViewManager extends ViewGroupManager<DocumentView> {
 
     // Hygen Generated Methods
 
+    public void setStampImageData(int tag, String annotationId, int pageNumber, String stampImageDataUrl) throws PDFNetException {
+        DocumentView documentView = mDocumentViews.get(tag);
+        if (documentView != null) {
+            documentView.setStampImageData(annotationId, pageNumber, stampImageDataUrl);
+        } else {
+            throw new PDFNetException("", 0L, getName(), "setStampImageData", "Unable to find DocumentView.");
+        }
+    }
+
     @Override
     public boolean needsCustomLayoutForChildren() {
         return true;

--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -22,6 +22,7 @@ import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 
 import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.Promise;
 import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.bridge.ReadableMap;
@@ -99,10 +100,10 @@ import com.pdftron.reactnative.R;
 import com.pdftron.reactnative.nativeviews.RNCollabViewerTabHostFragment;
 import com.pdftron.reactnative.nativeviews.RNPdfViewCtrlTabFragment;
 import com.pdftron.reactnative.nativeviews.RNPdfViewCtrlTabHostFragment;
+import com.pdftron.reactnative.utils.DocumentViewUtilsKt;
+import com.pdftron.reactnative.utils.DownloadFileCallback;
 import com.pdftron.reactnative.utils.ReactUtils;
-import com.pdftron.sdf.Doc;
 import com.pdftron.sdf.Obj;
-import com.pdftron.sdf.SDFDoc;
 
 import org.apache.commons.io.FileUtils;
 import org.json.JSONException;
@@ -4871,49 +4872,61 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
     }
 
     // Hygen Generated Methods
-    public void setStampImageData(String annotationId, int pageNumber, String stampImageDataUrl) throws PDFNetException {
-
-        Doc doc = getPdfDoc().getSDFDoc();
+    public void setStampImageData(String annotationId, int pageNumber, String stampImageDataUrl, Promise promise) throws PDFNetException {
         // Initialize a new ElementWriter and ElementBuilder
         ElementWriter writer = new ElementWriter();
         ElementBuilder builder = new ElementBuilder();
 
-        writer.begin(doc, true);
-        File imageFile = new File("/data/data/com.pdftron.completereader/files/image389.png");
+        writer.begin(getPdfViewCtrl().getDoc().getSDFDoc(), true);
 
-        Annot annot = ViewerUtils.getAnnotById(doc, annotationId, pageNumber);
+        Annot annot = ViewerUtils.getAnnotById(getPdfViewCtrl().getDoc(), annotationId, pageNumber);
+        File file = new File(getContext().getFilesDir(), "image.png");
+        DocumentViewUtilsKt.downloadFromURL(stampImageDataUrl, file.getAbsolutePath(), new DownloadFileCallback() {
+            @Override
+            public void downloadSuccess(@NonNull String path) {
+                // Initialize the new image
+                int w, h = 0;
+                try {
+                    Image image = Image.create(getPdfViewCtrl().getDoc().getSDFDoc(), path);
 
-        // Initialize the new image
-        Image image = Image.create(doc, imageFile.getAbsolutePath());
-        int w = image.getImageWidth();
-        int h = image.getImageHeight();
+                    w = image.getImageWidth();
+                    h = image.getImageHeight();
+                    // Initialize a new image element
+                    Element element = builder.createImage(image, 0, 0, w, h);
 
-        // Initialize a new image element
-        Element element = builder.createImage(image, 0, 0, w, h);
+                    // Write the element
+                    writer.writePlacedElement(element);
 
-        // Write the element
-        writer.writePlacedElement(element);
+                    // Get the bounding box of the new element
+                    com.pdftron.pdf.Rect bbox = element.getBBox();
 
-        // Get the bounding box of the new element
-        com.pdftron.pdf.Rect bbox = element.getBBox();
+                    // Configure the appearance stream that will be written to the annotation
+                    Obj new_appearance_stream = writer.end();
 
-        // Configure the appearance stream that will be written to the annotation
-        Obj new_appearance_stream = writer.end();
+                    // Set the bounding box to be the rect of the new element
+                    new_appearance_stream.putRect(
+                            "BBox",
+                            bbox.getX1(),
+                            bbox.getY1(),
+                            bbox.getX2(),
+                            bbox.getY2());
 
-        // Set the bounding box to be the rect of the new element
-        new_appearance_stream.putRect(
-                "BBox",
-                bbox.getX1(),
-                bbox.getY1(),
-                bbox.getX2(),
-                bbox.getY2());
+                    // Overwrite the annotation's appearance with the new appearance stream
+                    annot.setAppearance(new_appearance_stream);
 
-        // Overwrite the annotation's appearance with the new appearance stream
-        annot.setAppearance(new_appearance_stream);
+                    getPdfViewCtrl().update(annot, pageNumber);
+                } catch (PDFNetException e) {
+                    e.printStackTrace();
+                }
+                promise.resolve(annotationId);
+            }
 
-        getPdfViewCtrl().update(annot, 1);
+            @Override
+            public void downloadFailed(@NonNull Exception e) {
+                promise.reject("setStampData Error", e);
+            }
+        });
     }
-
 
     public void setSaveStateEnabled(boolean saveStateEnabled) {
         mSaveStateEnabled = saveStateEnabled;

--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -4881,7 +4881,7 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
         writer.begin(doc, true);
         File imageFile = new File("/data/data/com.pdftron.completereader/files/image389.png");
 
-        Annot annot = ViewerUtils.getAnnotById(doc, "a3302f72-bfef-664c-b2d3-28055684b483", 1);
+        Annot annot = ViewerUtils.getAnnotById(doc, annotationId, pageNumber);
 
         // Initialize the new image
         Image image = Image.create(doc, imageFile.getAbsolutePath());

--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -43,7 +43,11 @@ import com.pdftron.pdf.ActionParameter;
 import com.pdftron.pdf.Annot;
 import com.pdftron.pdf.ColorPt;
 import com.pdftron.pdf.DigitalSignatureField;
+import com.pdftron.pdf.Element;
+import com.pdftron.pdf.ElementBuilder;
+import com.pdftron.pdf.ElementWriter;
 import com.pdftron.pdf.Field;
+import com.pdftron.pdf.Image;
 import com.pdftron.pdf.PDFDoc;
 import com.pdftron.pdf.PDFViewCtrl;
 import com.pdftron.pdf.Page;
@@ -96,7 +100,9 @@ import com.pdftron.reactnative.nativeviews.RNCollabViewerTabHostFragment;
 import com.pdftron.reactnative.nativeviews.RNPdfViewCtrlTabFragment;
 import com.pdftron.reactnative.nativeviews.RNPdfViewCtrlTabHostFragment;
 import com.pdftron.reactnative.utils.ReactUtils;
+import com.pdftron.sdf.Doc;
 import com.pdftron.sdf.Obj;
+import com.pdftron.sdf.SDFDoc;
 
 import org.apache.commons.io.FileUtils;
 import org.json.JSONException;
@@ -4865,6 +4871,49 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
     }
 
     // Hygen Generated Methods
+    public void setStampImageData(String annotationId, int pageNumber, String stampImageDataUrl) throws PDFNetException {
+
+        Doc doc = getPdfDoc().getSDFDoc();
+        // Initialize a new ElementWriter and ElementBuilder
+        ElementWriter writer = new ElementWriter();
+        ElementBuilder builder = new ElementBuilder();
+
+        writer.begin(doc, true);
+        File imageFile = new File("/data/data/com.pdftron.completereader/files/image389.png");
+
+        Annot annot = ViewerUtils.getAnnotById(doc, "a3302f72-bfef-664c-b2d3-28055684b483", 1);
+
+        // Initialize the new image
+        Image image = Image.create(doc, imageFile.getAbsolutePath());
+        int w = image.getImageWidth();
+        int h = image.getImageHeight();
+
+        // Initialize a new image element
+        Element element = builder.createImage(image, 0, 0, w, h);
+
+        // Write the element
+        writer.writePlacedElement(element);
+
+        // Get the bounding box of the new element
+        com.pdftron.pdf.Rect bbox = element.getBBox();
+
+        // Configure the appearance stream that will be written to the annotation
+        Obj new_appearance_stream = writer.end();
+
+        // Set the bounding box to be the rect of the new element
+        new_appearance_stream.putRect(
+                "BBox",
+                bbox.getX1(),
+                bbox.getY1(),
+                bbox.getX2(),
+                bbox.getY2());
+
+        // Overwrite the annotation's appearance with the new appearance stream
+        annot.setAppearance(new_appearance_stream);
+
+        getPdfViewCtrl().update(annot, 1);
+    }
+
 
     public void setSaveStateEnabled(boolean saveStateEnabled) {
         mSaveStateEnabled = saveStateEnabled;

--- a/example/App.js
+++ b/example/App.js
@@ -21,8 +21,10 @@ export default class App extends Component<Props> {
   onLeadingNavButtonPressed = () => {
     console.log('leading nav button pressed');
     if (this._viewer) {
-      this._viewer.exportAnnotations().then((xfdf) => {
-        console.log('xfdf', xfdf);
+      this._viewer.setStampImageData().then((annotationId, pageNumber, stampImageDataUrl) => {
+        annotationID = '75911d3a-f1fa-7a4f-8137-5885e3a4c4ae',
+        pageNumber = 1,
+        stampImageData = 'https://media.sproutsocial.com/uploads/2017/02/10x-featured-social-media-image-size.png';
       });
     }
 
@@ -66,6 +68,12 @@ export default class App extends Component<Props> {
     console.log('xfdfCommand', xfdfCommand);
   }
 
+  setStampImageData = ({annotationId, pageNumber, stampImageDataUrl}) => {
+    annotationID = '75911d3a-f1fa-7a4f-8137-5885e3a4c4ae',
+    pageNumber = 1,
+    stampImageData = 'https://media.sproutsocial.com/uploads/2017/02/10x-featured-social-media-image-size.png';
+  }
+
   render() {
     const path = "https://pdftron.s3.amazonaws.com/downloads/pl/PDFTRON_about.pdf";
     const myToolbar = {
@@ -97,6 +105,8 @@ export default class App extends Component<Props> {
           disabledTools={[Config.Tools.annotationCreateLine, Config.Tools.annotationCreateRectangle]}
           fitMode={Config.FitMode.FitPage}
           layoutMode={Config.LayoutMode.Continuous}
+          setStampImageData = {this.setStampImageData}
+          openOutlineList = {true}
         />
     );
   }

--- a/ios/RNTPTDocumentView.h
+++ b/ios/RNTPTDocumentView.h
@@ -730,6 +730,8 @@ static NSString * const PTSignaturesManager_signatureDirectory = @"PTSignaturesM
 -(NSString *)getSavedSignatureFolder;
 
 // Hygen Generated Methods
+- (void)setStampImageData:(NSString *)annotationId pageNumber:(NSInteger)pageNumber stampImageDataUrl:(NSString *)stampImageDataUrl;
+
 @end
 
 

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -6120,88 +6120,90 @@ NS_ASSUME_NONNULL_END
 
 #pragma mark - Hygen Generated Props/Methods
 
-//- (void)setStampImageData:(NSString *)annotationId pageNumber:(NSInteger)pageNumber stampImageDataUrl:(NSString *)stampImageDataUrl
-//{
-//    if (stampImageDataUrl) {
-//
-//        PTPDFDoc* doc = [self.currentDocumentViewController.pdfViewCtrl GetDoc];
-//
-//        // Initialize a new PTElementWriter and PTElementBuilder
-//        PTElementWriter* writer = [[PTElementWriter alloc] init];
-//        PTElementBuilder* builder = [[PTElementBuilder alloc] init];
-//
-//        [writer WriterBeginWithSDFDoc:[doc GetSDFDoc] compress:YES];
-//
-//        __block UIImage *image = nil;
-//        NSURL *imageUrl = [NSURL URLWithString: stampImageDataUrl];
-//        //async download URL
-//        //async task to download data
-//        NSURLSessionDataTask* task = [NSURLSession.sharedSession dataTaskWithURL:imageUrl completionHandler:^(NSData * _Nullable data,
-//                                                                                                                       NSURLResponse * _Nullable response, NSError * _Nullable error) {
-//                if (!error) {
-//                    image = [[UIImage alloc] initWithData:data];
-//                }
-//
-//                if (image != nil) {
-//                    PTPDFViewCtrl *pdfViewCtrl = self.currentDocumentViewController.pdfViewCtrl;
-//                    PTAnnot *annot = [self findAnnotWithUniqueID:annotationId
-//                                                    onPageNumber:(int)pageNumber
-//                                                     pdfViewCtrl:pdfViewCtrl];
-//
-//
-//                    // Initialize the new image with downloaded file
-//                    NSData* data = UIImageJPEGRepresentation(image, 0.7);
-//                           PTObjSet* hintSet = [[PTObjSet alloc] init];
-//                           PTObj* encoderHints = [hintSet CreateArray];
-//
-//                           NSString *compressionAlgorithm = @"png";
-//                           NSInteger compressionQuality = 50;
-//                           [encoderHints PushBackName:compressionAlgorithm];
-//                           [encoderHints PushBackName:@"Quality"];
-//                           [encoderHints PushBackNumber:compressionQuality];
-//                    PTImage* img = [PTImage CreateWithDataSimple:[doc GetSDFDoc] buf:data buf_size:data.length encoder_hints:encoderHints];
-//                    int w = [img GetImageWidth], h = [img GetImageHeight];
-//
-//                    // Initialize a new image element
-//                    PTElement* img_element = [builder CreateImageWithCornerAndScale:img x:0 y:0 hscale:w vscale:h];
-//
-//                    // Write the element
-//                    [writer WritePlacedElement:img_element];
-//
-//                    // Get the bounding box of the new element
-//                    PTPDFRect* bbox = [img_element GetBBox];
-//
-//                    // Configure the appearance stream that will be written to the annotation
-//                    PTObj* appearance_stream = [writer End];
-//
-//                    // Set the bounding box to be the rect of the new element
-//                    [appearance_stream PutRect:@"BBox" x1:[bbox GetX1] y1:[bbox GetY1] x2:[bbox GetX2] y2:[bbox GetY1]];
-//
-//                    // Overwrite the annotation's appearance with the new appearance stream
-//                    [annot SetAppearance:appearance_stream annot_state:e_ptnormal app_state:0];
-//                }
-//            }];
-//
-//        [task resume];
-//
-//    }
-//}
-
 - (void)setStampImageData:(NSString *)annotationId pageNumber:(NSInteger)pageNumber stampImageDataUrl:(NSString *)stampImageDataUrl
 {
-    
-    PTPDFDoc* doc = [self.currentDocumentViewController.pdfViewCtrl GetDoc];
-    
-    // Initialize a new PTElementWriter and PTElementBuilder
-    PTElementWriter* writer = [[PTElementWriter alloc] init];
-    PTElementBuilder* builder = [[PTElementBuilder alloc] init];
+    if (stampImageDataUrl) {
 
-    [writer WriterBeginWithSDFDoc:[doc GetSDFDoc] compress:YES];
+        PTPDFDoc* doc = [self.currentDocumentViewController.pdfViewCtrl GetDoc];
 
-    PTPDFViewCtrl *pdfViewCtrl = self.currentDocumentViewController.pdfViewCtrl;
-    PTAnnot *annot = [self findAnnotWithUniqueID:annotationId
-                            onPageNumber:(int)pageNumber
-                            pdfViewCtrl:pdfViewCtrl];
+        // Initialize a new PTElementWriter and PTElementBuilder
+        PTElementWriter* writer = [[PTElementWriter alloc] init];
+        PTElementBuilder* builder = [[PTElementBuilder alloc] init];
+
+        [writer WriterBeginWithSDFDoc:[doc GetSDFDoc] compress:YES];
+
+        __block UIImage *image = nil;
+        NSURL *imageUrl = [NSURL URLWithString: stampImageDataUrl];
+        //async download URL
+        //async task to download data
+        NSURLSessionDataTask* task = [NSURLSession.sharedSession dataTaskWithURL:imageUrl completionHandler:^(NSData * _Nullable data,
+                                                                                                                       NSURLResponse * _Nullable response, NSError * _Nullable error) {
+                if (!error) {
+                    image = [[UIImage alloc] initWithData:data];
+                }
+
+                if (image != nil) {
+                    PTPDFViewCtrl *pdfViewCtrl = self.currentDocumentViewController.pdfViewCtrl;
+                    PTAnnot *annot = [self findAnnotWithUniqueID:annotationId
+                                                    onPageNumber:(int)pageNumber
+                                                     pdfViewCtrl:pdfViewCtrl];
+
+
+                    // Initialize the new image with downloaded file
+                    NSData* data = UIImageJPEGRepresentation(image, 0.7);
+                           PTObjSet* hintSet = [[PTObjSet alloc] init];
+                           PTObj* encoderHints = [hintSet CreateArray];
+
+                           NSString *compressionAlgorithm = @"png";
+                           NSInteger compressionQuality = 50;
+                           [encoderHints PushBackName:compressionAlgorithm];
+                           [encoderHints PushBackName:@"Quality"];
+                           [encoderHints PushBackNumber:compressionQuality];
+                    PTImage* img = [PTImage CreateWithDataSimple:[doc GetSDFDoc] buf:data buf_size:data.length encoder_hints:encoderHints];
+                    int w = [img GetImageWidth], h = [img GetImageHeight];
+
+                    // Initialize a new image element
+                    PTElement* img_element = [builder CreateImageWithCornerAndScale:img x:0 y:0 hscale:w vscale:h];
+
+                    // Write the element
+                    [writer WritePlacedElement:img_element];
+
+                    // Get the bounding box of the new element
+                    PTPDFRect* bbox = [img_element GetBBox];
+
+                    // Configure the appearance stream that will be written to the annotation
+                    PTObj* appearance_stream = [writer End];
+
+                    // Set the bounding box to be the rect of the new element
+                    [appearance_stream PutRect:@"BBox" x1:[bbox GetX1] y1:[bbox GetY1] x2:[bbox GetX2] y2:[bbox GetY1]];
+
+                    // Overwrite the annotation's appearance with the new appearance stream
+                    [annot SetAppearance:appearance_stream annot_state:e_ptnormal app_state:0];
+                    
+                    [pdfViewCtrl UpdateWithAnnot:annot page_num:(int)pageNumber];
+                }
+            }];
+
+        [task resume];
+
+    }
+}
+
+//- (void)setStampImageData:(NSString *)annotationId pageNumber:(NSInteger)pageNumber stampImageDataUrl:(NSString *)stampImageDataUrl
+//{
+//    
+//    PTPDFDoc* doc = [self.currentDocumentViewController.pdfViewCtrl GetDoc];
+//    
+//    // Initialize a new PTElementWriter and PTElementBuilder
+//    PTElementWriter* writer = [[PTElementWriter alloc] init];
+//    PTElementBuilder* builder = [[PTElementBuilder alloc] init];
+//
+//    [writer WriterBeginWithSDFDoc:[doc GetSDFDoc] compress:YES];
+//
+//    PTPDFViewCtrl *pdfViewCtrl = self.currentDocumentViewController.pdfViewCtrl;
+//    PTAnnot *annot = [self findAnnotWithUniqueID:annotationId
+//                            onPageNumber:(int)pageNumber
+//                            pdfViewCtrl:pdfViewCtrl];
 
     // Initialize the new image
 //    PTImage* img = [PTImage Create:[doc GetSDFDoc] filename:@"/Users/darrenchan/Library/Developer/CoreSimulator/Devices/08468861-B2FA-4514-8676-4063E62B5127/data/Downloads/image370.png"];
@@ -6213,29 +6215,29 @@ NS_ASSUME_NONNULL_END
 //    [encoderHints PushBackName:compressionAlgorithm];
 //    [encoderHints PushBackName:@"Quality"];
 //    [encoderHints PushBackNumber:compressionQuality];
-    PTImage* img = [PTImage CreateWithFile:[doc GetSDFDoc] filename:@"/Users/darrenchan/Library/Developer/CoreSimulator/Devices/08468861-B2FA-4514-8676-4063E62B5127/data/Downloads/image389jpg.jpg" encoder_hints:nil];
-    int w = [img GetImageWidth], h = [img GetImageHeight];
-
-    // Initialize a new image element
-    PTElement* img_element = [builder CreateImageWithCornerAndScale:img x:0 y:0 hscale:w vscale:h];
-
-    // Write the element
-    [writer WritePlacedElement:img_element];
-
-    // Get the bounding box of the new element
-    PTPDFRect* bbox = [img_element GetBBox];
-
-    // Configure the appearance stream that will be written to the annotation
-    PTObj* appearance_stream = [writer End];
-
-    // Set the bounding box to be the rect of the new element
-    [appearance_stream PutRect:@"BBox" x1:[bbox GetX1] y1:[bbox GetY1] x2:[bbox GetX2] y2:[bbox GetY1]];
-
-    // Overwrite the annotation's appearance with the new appearance stream
-    [annot SetAppearance:appearance_stream annot_state:e_ptnormal app_state:0];
-    
-    [pdfViewCtrl UpdateWithAnnot:annot page_num:(int)pageNumber];
-}
+//    PTImage* img = [PTImage CreateWithFile:[doc GetSDFDoc] filename:@"/Users/darrenchan/Library/Developer/CoreSimulator/Devices/08468861-B2FA-4514-8676-4063E62B5127/data/Downloads/image389jpg.jpg" encoder_hints:nil];
+//    int w = [img GetImageWidth], h = [img GetImageHeight];
+//
+//    // Initialize a new image element
+//    PTElement* img_element = [builder CreateImageWithCornerAndScale:img x:0 y:0 hscale:w vscale:h];
+//
+//    // Write the element
+//    [writer WritePlacedElement:img_element];
+//
+//    // Get the bounding box of the new element
+//    PTPDFRect* bbox = [img_element GetBBox];
+//
+//    // Configure the appearance stream that will be written to the annotation
+//    PTObj* appearance_stream = [writer End];
+//
+//    // Set the bounding box to be the rect of the new element
+//    [appearance_stream PutRect:@"BBox" x1:[bbox GetX1] y1:[bbox GetY1] x2:[bbox GetX2] y2:[bbox GetY1]];
+//
+//    // Overwrite the annotation's appearance with the new appearance stream
+//    [annot SetAppearance:appearance_stream annot_state:e_ptnormal app_state:0];
+//    
+//    [pdfViewCtrl UpdateWithAnnot:annot page_num:(int)pageNumber];
+//}
 
 - (void)setSignatureColors:(NSArray *)signatureColors
 {

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -6120,6 +6120,123 @@ NS_ASSUME_NONNULL_END
 
 #pragma mark - Hygen Generated Props/Methods
 
+//- (void)setStampImageData:(NSString *)annotationId pageNumber:(NSInteger)pageNumber stampImageDataUrl:(NSString *)stampImageDataUrl
+//{
+//    if (stampImageDataUrl) {
+//
+//        PTPDFDoc* doc = [self.currentDocumentViewController.pdfViewCtrl GetDoc];
+//
+//        // Initialize a new PTElementWriter and PTElementBuilder
+//        PTElementWriter* writer = [[PTElementWriter alloc] init];
+//        PTElementBuilder* builder = [[PTElementBuilder alloc] init];
+//
+//        [writer WriterBeginWithSDFDoc:[doc GetSDFDoc] compress:YES];
+//
+//        __block UIImage *image = nil;
+//        NSURL *imageUrl = [NSURL URLWithString: stampImageDataUrl];
+//        //async download URL
+//        //async task to download data
+//        NSURLSessionDataTask* task = [NSURLSession.sharedSession dataTaskWithURL:imageUrl completionHandler:^(NSData * _Nullable data,
+//                                                                                                                       NSURLResponse * _Nullable response, NSError * _Nullable error) {
+//                if (!error) {
+//                    image = [[UIImage alloc] initWithData:data];
+//                }
+//
+//                if (image != nil) {
+//                    PTPDFViewCtrl *pdfViewCtrl = self.currentDocumentViewController.pdfViewCtrl;
+//                    PTAnnot *annot = [self findAnnotWithUniqueID:annotationId
+//                                                    onPageNumber:(int)pageNumber
+//                                                     pdfViewCtrl:pdfViewCtrl];
+//
+//
+//                    // Initialize the new image with downloaded file
+//                    NSData* data = UIImageJPEGRepresentation(image, 0.7);
+//                           PTObjSet* hintSet = [[PTObjSet alloc] init];
+//                           PTObj* encoderHints = [hintSet CreateArray];
+//
+//                           NSString *compressionAlgorithm = @"png";
+//                           NSInteger compressionQuality = 50;
+//                           [encoderHints PushBackName:compressionAlgorithm];
+//                           [encoderHints PushBackName:@"Quality"];
+//                           [encoderHints PushBackNumber:compressionQuality];
+//                    PTImage* img = [PTImage CreateWithDataSimple:[doc GetSDFDoc] buf:data buf_size:data.length encoder_hints:encoderHints];
+//                    int w = [img GetImageWidth], h = [img GetImageHeight];
+//
+//                    // Initialize a new image element
+//                    PTElement* img_element = [builder CreateImageWithCornerAndScale:img x:0 y:0 hscale:w vscale:h];
+//
+//                    // Write the element
+//                    [writer WritePlacedElement:img_element];
+//
+//                    // Get the bounding box of the new element
+//                    PTPDFRect* bbox = [img_element GetBBox];
+//
+//                    // Configure the appearance stream that will be written to the annotation
+//                    PTObj* appearance_stream = [writer End];
+//
+//                    // Set the bounding box to be the rect of the new element
+//                    [appearance_stream PutRect:@"BBox" x1:[bbox GetX1] y1:[bbox GetY1] x2:[bbox GetX2] y2:[bbox GetY1]];
+//
+//                    // Overwrite the annotation's appearance with the new appearance stream
+//                    [annot SetAppearance:appearance_stream annot_state:e_ptnormal app_state:0];
+//                }
+//            }];
+//
+//        [task resume];
+//
+//    }
+//}
+
+- (void)setStampImageData:(NSString *)annotationId pageNumber:(NSInteger)pageNumber stampImageDataUrl:(NSString *)stampImageDataUrl
+{
+    
+    PTPDFDoc* doc = [self.currentDocumentViewController.pdfViewCtrl GetDoc];
+    
+    // Initialize a new PTElementWriter and PTElementBuilder
+    PTElementWriter* writer = [[PTElementWriter alloc] init];
+    PTElementBuilder* builder = [[PTElementBuilder alloc] init];
+
+    [writer WriterBeginWithSDFDoc:[doc GetSDFDoc] compress:YES];
+
+    PTPDFViewCtrl *pdfViewCtrl = self.currentDocumentViewController.pdfViewCtrl;
+    PTAnnot *annot = [self findAnnotWithUniqueID:annotationId
+                            onPageNumber:(int)pageNumber
+                            pdfViewCtrl:pdfViewCtrl];
+
+    // Initialize the new image
+//    PTImage* img = [PTImage Create:[doc GetSDFDoc] filename:@"/Users/darrenchan/Library/Developer/CoreSimulator/Devices/08468861-B2FA-4514-8676-4063E62B5127/data/Downloads/image370.png"];
+//    PTObjSet* hintSet = [[PTObjSet alloc] init];
+//    PTObj* encoderHints = [hintSet CreateArray];
+//
+//    NSString *compressionAlgorithm = @"JPEG";
+//    NSInteger compressionQuality = 50;
+//    [encoderHints PushBackName:compressionAlgorithm];
+//    [encoderHints PushBackName:@"Quality"];
+//    [encoderHints PushBackNumber:compressionQuality];
+    PTImage* img = [PTImage CreateWithFile:[doc GetSDFDoc] filename:@"/Users/darrenchan/Library/Developer/CoreSimulator/Devices/08468861-B2FA-4514-8676-4063E62B5127/data/Downloads/image389jpg.jpg" encoder_hints:nil];
+    int w = [img GetImageWidth], h = [img GetImageHeight];
+
+    // Initialize a new image element
+    PTElement* img_element = [builder CreateImageWithCornerAndScale:img x:0 y:0 hscale:w vscale:h];
+
+    // Write the element
+    [writer WritePlacedElement:img_element];
+
+    // Get the bounding box of the new element
+    PTPDFRect* bbox = [img_element GetBBox];
+
+    // Configure the appearance stream that will be written to the annotation
+    PTObj* appearance_stream = [writer End];
+
+    // Set the bounding box to be the rect of the new element
+    [appearance_stream PutRect:@"BBox" x1:[bbox GetX1] y1:[bbox GetY1] x2:[bbox GetX2] y2:[bbox GetY1]];
+
+    // Overwrite the annotation's appearance with the new appearance stream
+    [annot SetAppearance:appearance_stream annot_state:e_ptnormal app_state:0];
+    
+    [pdfViewCtrl UpdateWithAnnot:annot page_num:(int)pageNumber];
+}
+
 - (void)setSignatureColors:(NSArray *)signatureColors
 {
     _signatureColors = [signatureColors copy];

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -6122,122 +6122,64 @@ NS_ASSUME_NONNULL_END
 
 - (void)setStampImageData:(NSString *)annotationId pageNumber:(NSInteger)pageNumber stampImageDataUrl:(NSString *)stampImageDataUrl
 {
-    if (stampImageDataUrl) {
-
-        PTPDFDoc* doc = [self.currentDocumentViewController.pdfViewCtrl GetDoc];
-
-        // Initialize a new PTElementWriter and PTElementBuilder
-        PTElementWriter* writer = [[PTElementWriter alloc] init];
-        PTElementBuilder* builder = [[PTElementBuilder alloc] init];
-
-        [writer WriterBeginWithSDFDoc:[doc GetSDFDoc] compress:YES];
-
-        __block UIImage *image = nil;
-        NSURL *imageUrl = [NSURL URLWithString: stampImageDataUrl];
-        //async download URL
-        //async task to download data
-        NSURLSessionDataTask* task = [NSURLSession.sharedSession dataTaskWithURL:imageUrl completionHandler:^(NSData * _Nullable data,
-                                                                                                                       NSURLResponse * _Nullable response, NSError * _Nullable error) {
-                if (!error) {
-                    image = [[UIImage alloc] initWithData:data];
-                }
-
-                if (image != nil) {
-                    PTPDFViewCtrl *pdfViewCtrl = self.currentDocumentViewController.pdfViewCtrl;
-                    PTAnnot *annot = [self findAnnotWithUniqueID:annotationId
-                                                    onPageNumber:(int)pageNumber
-                                                     pdfViewCtrl:pdfViewCtrl];
-
-
-                    // Initialize the new image with downloaded file
-                    NSData* data = UIImageJPEGRepresentation(image, 0.7);
-                           PTObjSet* hintSet = [[PTObjSet alloc] init];
-                           PTObj* encoderHints = [hintSet CreateArray];
-
-                           NSString *compressionAlgorithm = @"png";
-                           NSInteger compressionQuality = 50;
-                           [encoderHints PushBackName:compressionAlgorithm];
-                           [encoderHints PushBackName:@"Quality"];
-                           [encoderHints PushBackNumber:compressionQuality];
-                    PTImage* img = [PTImage CreateWithDataSimple:[doc GetSDFDoc] buf:data buf_size:data.length encoder_hints:encoderHints];
-                    int w = [img GetImageWidth], h = [img GetImageHeight];
-
-                    // Initialize a new image element
-                    PTElement* img_element = [builder CreateImageWithCornerAndScale:img x:0 y:0 hscale:w vscale:h];
-
-                    // Write the element
-                    [writer WritePlacedElement:img_element];
-
-                    // Get the bounding box of the new element
-                    PTPDFRect* bbox = [img_element GetBBox];
-
-                    // Configure the appearance stream that will be written to the annotation
-                    PTObj* appearance_stream = [writer End];
-
-                    // Set the bounding box to be the rect of the new element
-                    [appearance_stream PutRect:@"BBox" x1:[bbox GetX1] y1:[bbox GetY1] x2:[bbox GetX2] y2:[bbox GetY1]];
-
-                    // Overwrite the annotation's appearance with the new appearance stream
-                    [annot SetAppearance:appearance_stream annot_state:e_ptnormal app_state:0];
-                    
-                    [pdfViewCtrl UpdateWithAnnot:annot page_num:(int)pageNumber];
-                }
-            }];
-
+    NSURL *imageUrl = [NSURL URLWithString: stampImageDataUrl];
+        
+        NSURLSessionDataTask* task = [NSURLSession.sharedSession dataTaskWithURL:imageUrl completionHandler:^(NSData * _Nullable data, NSURLResponse * _Nullable response, NSError * _Nullable error) {
+            if (error) {
+                return;
+            }
+                        
+            // Initialize the new image with downloaded file
+            PTObjSet* hintSet = [[PTObjSet alloc] init];
+            PTObj* encoderHints = [hintSet CreateArray];
+            
+            NSString *compressionAlgorithm = @"png";
+            NSInteger compressionQuality = 50;
+            [encoderHints PushBackName:compressionAlgorithm];
+            [encoderHints PushBackName:@"Quality"];
+            [encoderHints PushBackNumber:compressionQuality];
+            PTPDFDoc* doc = [self.currentDocumentViewController.pdfViewCtrl GetDoc];
+            PTImage* image = [PTImage CreateWithDataSimple:[doc GetSDFDoc] buf:data buf_size:data.length encoder_hints:encoderHints];
+            
+            PTAnnot *annot = [self findAnnotWithUniqueID:annotationId
+                                            onPageNumber:(int)pageNumber
+                                             pdfViewCtrl:self.currentDocumentViewController.pdfViewCtrl];
+            [self setCustomImage:image OnAnnotation:annot onDoc:doc];
+            [self.currentDocumentViewController.pdfViewCtrl UpdateWithAnnot:annot page_num:(int)pageNumber];
+        }];
+        
         [task resume];
 
-    }
 }
 
-//- (void)setStampImageData:(NSString *)annotationId pageNumber:(NSInteger)pageNumber stampImageDataUrl:(NSString *)stampImageDataUrl
-//{
-//    
-//    PTPDFDoc* doc = [self.currentDocumentViewController.pdfViewCtrl GetDoc];
-//    
-//    // Initialize a new PTElementWriter and PTElementBuilder
-//    PTElementWriter* writer = [[PTElementWriter alloc] init];
-//    PTElementBuilder* builder = [[PTElementBuilder alloc] init];
-//
-//    [writer WriterBeginWithSDFDoc:[doc GetSDFDoc] compress:YES];
-//
-//    PTPDFViewCtrl *pdfViewCtrl = self.currentDocumentViewController.pdfViewCtrl;
-//    PTAnnot *annot = [self findAnnotWithUniqueID:annotationId
-//                            onPageNumber:(int)pageNumber
-//                            pdfViewCtrl:pdfViewCtrl];
+- (void)setCustomImage:(PTImage*)image OnAnnotation:(PTAnnot*)annot onDoc:(PTPDFDoc*)doc
+{
+    // Initialize a new PTElementWriter and PTElementBuilder
+    PTElementWriter* writer = [[PTElementWriter alloc] init];
+    PTElementBuilder* builder = [[PTElementBuilder alloc] init];
 
-    // Initialize the new image
-//    PTImage* img = [PTImage Create:[doc GetSDFDoc] filename:@"/Users/darrenchan/Library/Developer/CoreSimulator/Devices/08468861-B2FA-4514-8676-4063E62B5127/data/Downloads/image370.png"];
-//    PTObjSet* hintSet = [[PTObjSet alloc] init];
-//    PTObj* encoderHints = [hintSet CreateArray];
-//
-//    NSString *compressionAlgorithm = @"JPEG";
-//    NSInteger compressionQuality = 50;
-//    [encoderHints PushBackName:compressionAlgorithm];
-//    [encoderHints PushBackName:@"Quality"];
-//    [encoderHints PushBackNumber:compressionQuality];
-//    PTImage* img = [PTImage CreateWithFile:[doc GetSDFDoc] filename:@"/Users/darrenchan/Library/Developer/CoreSimulator/Devices/08468861-B2FA-4514-8676-4063E62B5127/data/Downloads/image389jpg.jpg" encoder_hints:nil];
-//    int w = [img GetImageWidth], h = [img GetImageHeight];
-//
-//    // Initialize a new image element
-//    PTElement* img_element = [builder CreateImageWithCornerAndScale:img x:0 y:0 hscale:w vscale:h];
-//
-//    // Write the element
-//    [writer WritePlacedElement:img_element];
-//
-//    // Get the bounding box of the new element
-//    PTPDFRect* bbox = [img_element GetBBox];
-//
-//    // Configure the appearance stream that will be written to the annotation
-//    PTObj* appearance_stream = [writer End];
-//
-//    // Set the bounding box to be the rect of the new element
-//    [appearance_stream PutRect:@"BBox" x1:[bbox GetX1] y1:[bbox GetY1] x2:[bbox GetX2] y2:[bbox GetY1]];
-//
-//    // Overwrite the annotation's appearance with the new appearance stream
-//    [annot SetAppearance:appearance_stream annot_state:e_ptnormal app_state:0];
-//    
-//    [pdfViewCtrl UpdateWithAnnot:annot page_num:(int)pageNumber];
-//}
+    [writer WriterBeginWithSDFDoc:[doc GetSDFDoc] compress:YES];
+
+    int w = [image GetImageWidth], h = [image GetImageHeight];
+
+    // Initialize a new image element
+    PTElement* img_element = [builder CreateImageWithCornerAndScale:image x:0 y:0 hscale:w vscale:h];
+
+    // Write the element
+    [writer WritePlacedElement:img_element];
+
+    // Get the bounding box of the new element
+    PTPDFRect* bbox = [img_element GetBBox];
+
+    // Configure the appearance stream that will be written to the annotation
+    PTObj* appearance_stream = [writer End];
+
+    // Set the bounding box to be the rect of the new element
+    [appearance_stream PutRect:@"BBox" x1:[bbox GetX1] y1:[bbox GetY1] x2:[bbox GetX2] y2:[bbox GetY2]];
+
+    // Overwrite the annotation's appearance with the new appearance stream
+    [annot SetAppearance:appearance_stream annot_state:e_ptnormal app_state:0];
+}
 
 - (void)setSignatureColors:(NSArray *)signatureColors
 {

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -6205,6 +6205,7 @@ NS_ASSUME_NONNULL_END
 
     // Overwrite the annotation's appearance with the new appearance stream
     [annot SetAppearance:appearance_stream annot_state:e_ptnormal app_state:0];
+}
 
 - (void)setForceAppTheme:(NSString *)forcedAppTheme
 {

--- a/ios/RNTPTDocumentViewManager.h
+++ b/ios/RNTPTDocumentViewManager.h
@@ -196,5 +196,6 @@
 - (NSString *)getSavedSignatureFolderForDocumentViewTag:(NSNumber *)tag;
 
 #pragma mark - Hygen Generated Methods
+- (void)setStampImageDataForDocumentViewTag:(NSNumber *)tag annotationId:(NSString *)annotationId pageNumber:(NSInteger)pageNumber stampImageDataUrl:(NSString *)stampImageDataUrl;
 
 @end

--- a/ios/RNTPTDocumentViewManager.m
+++ b/ios/RNTPTDocumentViewManager.m
@@ -1685,6 +1685,16 @@ RCT_CUSTOM_VIEW_PROPERTY(signatureColors, NSArray, RNTPTDocumentView)
 }
 
 #pragma mark - Hygen Generated Methods
+- (void)setStampImageDataForDocumentViewTag:(NSNumber *)tag annotationId:(NSString *)annotationId pageNumber:(NSInteger)pageNumber stampImageDataUrl:(NSString *)stampImageDataUrl
+{
+    RNTPTDocumentView *documentView = self.documentViews[tag];
+    if (documentView) {
+        [documentView setStampImageData:annotationId pageNumber:pageNumber stampImageDataUrl:stampImageDataUrl];
+    } else {
+        @throw [NSException exceptionWithName:NSInvalidArgumentException reason:@"Unable to get field for tag" userInfo:nil];
+    }
+}
+
 
 #pragma mark - Coordination
 

--- a/ios/RNTPTDocumentViewModule.m
+++ b/ios/RNTPTDocumentViewModule.m
@@ -1409,5 +1409,20 @@ RCT_REMAP_METHOD(importAnnotationCommand,
 }
 
 #pragma mark - Hygen Generated Methods
-
+RCT_REMAP_METHOD(setStampImageData,
+                 setStampImageDataForDocumentViewTag:(nonnull NSNumber *)tag
+                 annotationId:(NSString *)annotationId
+                 pageNumber:(NSInteger)pageNumber
+                 stampImageDataUrl:(NSString *)stampImageDataUrl
+                 resolver:(RCTPromiseResolveBlock)resolve
+                 rejecter:(RCTPromiseRejectBlock)reject)
+{
+    @try {
+        [[self documentViewManager] setStampImageDataForDocumentViewTag:tag annotationId:annotationId pageNumber:pageNumber stampImageDataUrl:stampImageDataUrl];
+        resolve(nil);
+    }
+    @catch (NSException *exception) {
+        reject(@"set_stamp_image_data", @"Failed to set stamp image data", [self errorFromException:exception]);
+    }
+}
 @end

--- a/lib/src/DocumentView/DocumentView.js
+++ b/lib/src/DocumentView/DocumentView.js
@@ -563,6 +563,13 @@ export class DocumentView extends PureComponent {
         return Promise.resolve();
     };
     // Hygen Generated Methods
+    setStampImageData = (annotationId, pageNumber, stampImageDataUrl) => {
+        const tag = findNodeHandle(this._viewerRef);
+        if (tag != null) {
+            return DocumentViewManager.setStampImageData(tag, annotationId, pageNumber, stampImageDataUrl);
+        }
+        return Promise.resolve();
+    };
     /**
     * note: this function exists for supporting the old version. It simply calls setValuesForFields.
     *

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,117 @@
+{
+  "name": "react-native-pdftron",
+  "version": "3.0.2-beta.142",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@react-native/normalize-color": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@react-native/normalize-color/-/normalize-color-2.1.0.tgz",
+      "integrity": "sha512-Z1jQI2NpdFJCVgpY+8Dq/Bt3d+YUi1928Q+/CZm/oh66fzM0RUl54vvuXlPJKybH4pdCZey1eDTPaLHkMPNgWA=="
+    },
+    "@types/prop-types": {
+      "version": "15.7.5",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
+      "integrity": "sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==",
+      "dev": true
+    },
+    "@types/react": {
+      "version": "18.0.25",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.25.tgz",
+      "integrity": "sha512-xD6c0KDT4m7n9uD4ZHi02lzskaiqcBxf4zi+tXZY98a04wvc0hi/TcCPC2FOESZi51Nd7tlUeOJY8RofL799/g==",
+      "dev": true,
+      "requires": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "@types/react-native": {
+      "version": "0.70.6",
+      "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.70.6.tgz",
+      "integrity": "sha512-ynQ2jj0km9d7dbnyKqVdQ6Nti7VQ8SLTA/KKkkS5+FnvGyvij2AOo1/xnkBR/jnSNXuzrvGVzw2n0VWfppmfKw==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/scheduler": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
+      "dev": true
+    },
+    "csstype": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
+      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==",
+      "dev": true
+    },
+    "deprecated-react-native-prop-types": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/deprecated-react-native-prop-types/-/deprecated-react-native-prop-types-2.3.0.tgz",
+      "integrity": "sha512-pWD0voFtNYxrVqvBMYf5gq3NA2GCpfodS1yNynTPc93AYA/KEMGeWDqqeUB6R2Z9ZofVhks2aeJXiuQqKNpesA==",
+      "requires": {
+        "@react-native/normalize-color": "*",
+        "invariant": "*",
+        "prop-types": "*"
+      }
+    },
+    "invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "requires": {
+        "loose-envify": "^1.0.0"
+      }
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "requires": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
+    },
+    "prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "requires": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "react": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+      "dev": true,
+      "requires": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "typescript": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "3.0.3-4",
+  "version": "3.0.3-5",
   "description": "React Native Pdftron",
   "main": "./lib/index.js",
   "typings": "index.ts",

--- a/src/DocumentView/DocumentView.tsx
+++ b/src/DocumentView/DocumentView.tsx
@@ -582,6 +582,13 @@ export class DocumentView extends PureComponent<DocumentViewProps, any> {
   }
 
   // Hygen Generated Methods
+  setStampImageData = (annotationId: string, pageNumber: number, stampImageDataUrl: string): Promise<void> => {
+    const tag = findNodeHandle(this._viewerRef);
+    if (tag != null) {
+      return DocumentViewManager.setStampImageData(tag, annotationId, pageNumber, stampImageDataUrl);
+    }
+    return Promise.resolve();
+  }
 
   /**
   * note: this function exists for supporting the old version. It simply calls setValuesForFields.


### PR DESCRIPTION
To test:

Open doc with existing stamp annotation in respective platforms (iOS/Android have different paths to get docs)

in app.js override button:
replace annotationId in snippet with annotation id from doc
![image](https://user-images.githubusercontent.com/15988850/205758765-712dba70-a76f-4363-bb95-3e96b331ffb4.png)

```
try {
      await this._viewer.setStampImageData(
        annotationId = 'a3302f72-bfef-664c-b2d3-28055684b483', 
        pageNumber = 1, 
        stampImageDataUrl = 'https://media.sproutsocial.com/uploads/2017/02/10x-featured-social-media-image-size.png'
      )
    } catch (e) {
      console.error(e)
    }

```