### PR TITLE
Fix forceAppTheme on iOS for UI Elements, not pdfviewctrl document

### DIFF
--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -2850,14 +2850,23 @@ NS_ASSUME_NONNULL_END
 
 - (void)applyForcedAppTheme
 {
+    // Force App Theme
     if (@available(iOS 13.0, *)) {
-        PTPDFViewCtrl *pdfViewCtrl = self.currentDocumentViewController.pdfViewCtrl;
-
-        if (pdfViewCtrl) {
-            if ([self.forceAppTheme isEqualToString:PTAppDarkTheme]) {
-                [pdfViewCtrl SetColorPostProcessMode:e_ptpostprocess_night_mode];
-            } else if ([self.forceAppTheme isEqualToString:PTAppLightTheme]) {
-                [pdfViewCtrl SetColorPostProcessMode:e_ptpostprocess_none];
+        if ([self.forceAppTheme isEqualToString:PTAppDarkTheme]) {
+            UIViewController * const viewController = self.viewController.navigationController;
+            viewController.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
+            
+            UIWindow * const window = self.window;
+            if (window) {
+                window.overrideUserInterfaceStyle = UIUserInterfaceStyleDark;
+            }
+        } else if ([self.forceAppTheme isEqualToString:PTAppLightTheme]) {
+            UIViewController * const viewController = self.viewController.navigationController;
+            viewController.overrideUserInterfaceStyle = UIUserInterfaceStyleLight;
+            
+            UIWindow * const window = self.window;
+            if (window) {
+                window.overrideUserInterfaceStyle = UIUserInterfaceStyleLight;
             }
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "3.0.3-2",
+  "version": "3.0.3-3",
   "description": "React Native Pdftron",
   "main": "./lib/index.js",
   "typings": "index.ts",


### PR DESCRIPTION
force UI elements, not pdfviewctrl object for forceAppThemeProp