### PR TITLE
[Support-35444] Fix issue for DateText annotation type being selected as AnnotationCreateFreeText

### DIFF
--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -2363,7 +2363,7 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
         annotPair.putInt(KEY_ANNOTATION_PAGE, pageNumber);
         // try to obtain bbox and type
         try {
-            annotPair.putString(KEY_ANNOTATION_TYPE, convAnnotTypeToString(annot.getType()));
+            annotPair.putString(KEY_ANNOTATION_TYPE, convAnnotTypeToString(AnnotUtils.getAnnotType(annot)));
             // screen rect
             com.pdftron.pdf.Rect screenRect = getPdfViewCtrl().getScreenRectForAnnot(annot, pageNumber);
             WritableMap screenRectMap = Arguments.createMap();

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "3.0.3-9",
+  "version": "3.0.3-10",
   "description": "React Native Pdftron",
   "main": "./lib/index.js",
   "typings": "index.ts",


### PR DESCRIPTION
Annotation selected should now be AnnotationCreateFreeTextDate