### PR TITLE
Added different annotation types for Form Field Annotation types 

### DIFF
--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -50,6 +50,7 @@ import com.pdftron.pdf.ElementWriter;
 import com.pdftron.pdf.Field;
 import com.pdftron.pdf.Image;
 import com.pdftron.pdf.PDFDoc;
+import com.pdftron.pdf.PDFNet;
 import com.pdftron.pdf.PDFViewCtrl;
 import com.pdftron.pdf.Page;
 import com.pdftron.pdf.ViewChangeCollection;
@@ -1294,7 +1295,7 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
     }
 
     @Nullable
-    private String convAnnotTypeToString(int annotType) {
+    private String convAnnotTypeToString(Annot annot, int annotType) {
         String annotString;
         switch (annotType) {
             case Annot.e_Ink:
@@ -1370,7 +1371,7 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
                 annotString = TOOL_ANNOTATION_CREATE_FREE_HIGHLIGHTER;
                 break;
             case Annot.e_Widget:
-                annotString = TOOL_FORM_CREATE_TEXT_FIELD;
+                annotString = getWidgetFieldType(annot);
                 break;
             case AnnotStyle.CUSTOM_ANNOT_TYPE_FREE_TEXT_DATE:
                 annotString = TOOL_ANNOTATION_CREATE_FREE_TEXT_DATE;
@@ -1380,6 +1381,34 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
                 break;
         }
         return annotString;
+    }
+
+    private String getWidgetFieldType(Annot annot) {
+        try {
+            if (annot != null && annot.isValid()) {
+                Widget widget = new Widget(annot);
+                Field field = widget.getField();
+                int fieldType = field.getType();
+                if (fieldType == Field.e_text) {
+                    return TOOL_FORM_CREATE_TEXT_FIELD;
+                }
+                else if (fieldType == Field.e_radio) {
+                    return TOOL_FORM_CREATE_RADIO_FIELD;
+                }
+                else if (fieldType == Field.e_check) {
+                    return TOOL_FORM_CREATE_CHECKBOX_FIELD;
+                }
+                else if (fieldType == Field.e_choice) {
+                    return TOOL_FORM_CREATE_COMBO_BOX_FIELD;
+                }
+                else if (fieldType == Field.e_signature) {
+                    return TOOL_FORM_CREATE_SIGNATURE_FIELD;
+                }
+            }
+        } catch (PDFNetException e) {
+            return "";
+        }
+        return "";
     }
 
     @Nullable
@@ -2363,7 +2392,7 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
         annotPair.putInt(KEY_ANNOTATION_PAGE, pageNumber);
         // try to obtain bbox and type
         try {
-            annotPair.putString(KEY_ANNOTATION_TYPE, convAnnotTypeToString(AnnotUtils.getAnnotType(annot)));
+            annotPair.putString(KEY_ANNOTATION_TYPE, convAnnotTypeToString(annot, AnnotUtils.getAnnotType(annot)));
             // screen rect
             com.pdftron.pdf.Rect screenRect = getPdfViewCtrl().getScreenRectForAnnot(annot, pageNumber);
             WritableMap screenRectMap = Arguments.createMap();
@@ -2700,7 +2729,7 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
                         annotData.putString(KEY_ANNOTATION_ID, Utils.isNullOrEmpty(uid) ? null : uid);
                         annotData.putInt(KEY_ANNOTATION_PAGE, entry.getValue());
                         try {
-                            annotData.putString(KEY_ANNOTATION_TYPE, convAnnotTypeToString(key.getType()));
+                            annotData.putString(KEY_ANNOTATION_TYPE, convAnnotTypeToString(key, key.getType()));
                         } catch (PDFNetException e) {
                             e.printStackTrace();
                         }
@@ -2914,7 +2943,7 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
             annotData.putString(KEY_ANNOTATION_ID, uid == null ? "" : uid);
             annotData.putInt(KEY_ANNOTATION_PAGE, entry.getValue());
             try {
-                annotData.putString(KEY_ANNOTATION_TYPE, convAnnotTypeToString(key.getType()));
+                annotData.putString(KEY_ANNOTATION_TYPE, convAnnotTypeToString(key, key.getType()));
             } catch (PDFNetException e) {
                 e.printStackTrace();
             }
@@ -2967,7 +2996,7 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
                 annotData.putString(KEY_ANNOTATION_ID, uid == null ? "" : uid);
                 annotData.putInt(KEY_ANNOTATION_PAGE, entry.getValue());
                 try {
-                    annotData.putString(KEY_ANNOTATION_TYPE, convAnnotTypeToString(key.getType()));
+                    annotData.putString(KEY_ANNOTATION_TYPE, convAnnotTypeToString(key, key.getType()));
                 } catch (PDFNetException e) {
                     e.printStackTrace();
                 }

--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -50,7 +50,6 @@ import com.pdftron.pdf.ElementWriter;
 import com.pdftron.pdf.Field;
 import com.pdftron.pdf.Image;
 import com.pdftron.pdf.PDFDoc;
-import com.pdftron.pdf.PDFNet;
 import com.pdftron.pdf.PDFViewCtrl;
 import com.pdftron.pdf.Page;
 import com.pdftron.pdf.ViewChangeCollection;
@@ -1391,17 +1390,13 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
                 int fieldType = field.getType();
                 if (fieldType == Field.e_text) {
                     return TOOL_FORM_CREATE_TEXT_FIELD;
-                }
-                else if (fieldType == Field.e_radio) {
+                } else if (fieldType == Field.e_radio) {
                     return TOOL_FORM_CREATE_RADIO_FIELD;
-                }
-                else if (fieldType == Field.e_check) {
+                } else if (fieldType == Field.e_check) {
                     return TOOL_FORM_CREATE_CHECKBOX_FIELD;
-                }
-                else if (fieldType == Field.e_choice) {
+                } else if (fieldType == Field.e_choice) {
                     return TOOL_FORM_CREATE_COMBO_BOX_FIELD;
-                }
-                else if (fieldType == Field.e_signature) {
+                } else if (fieldType == Field.e_signature) {
                     return TOOL_FORM_CREATE_SIGNATURE_FIELD;
                 }
             }
@@ -4992,7 +4987,6 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
             getPdfViewCtrl().update(true);
         }
     }
-
 
     public void setSaveStateEnabled(boolean saveStateEnabled) {
         mSaveStateEnabled = saveStateEnabled;

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -3686,7 +3686,7 @@ NS_ASSUME_NONNULL_END
     PTPDFRect *screenRect = [pdfViewCtrl GetScreenRectForAnnot:annot page_num:pageNumber];
     PTPDFRect *pageRect = [self convertScreenRectToPageRect:screenRect pageNumber:pageNumber pdfViewCtrl:pdfViewCtrl];
     
-    NSString *annotationType = [RNTPTDocumentView stringForAnnotType:[annot GetType]];
+    NSString *annotationType = [RNTPTDocumentView stringForAnnotType:annot type:[annot GetType]];
     
     return @{
         PTAnnotationIdKey: (uniqueId ?: @""),
@@ -4159,7 +4159,7 @@ NS_ASSUME_NONNULL_END
         [self.delegate annotationChanged:self annotation:@{
             PTAnnotationIdKey: annotId,
             PTAnnotationPageNumberKey: @(pageNumber),
-            PTAnnotationTypeKey: [RNTPTDocumentView stringForAnnotType:[annot GetType]],
+            PTAnnotationTypeKey: [RNTPTDocumentView stringForAnnotType:annot type:[annot GetType]],
         } action:PTAddAnnotationActionKey];
     }
     if (!self.collaborationManager) {
@@ -4170,7 +4170,7 @@ NS_ASSUME_NONNULL_END
         [collabAnnot setAnnotationID:annotId];
         [collabAnnot setXfdf:[self generateXfdfCommand:[[PTVectorAnnot alloc] init] modified:annots deleted:[[PTVectorAnnot alloc] init] pdfViewCtrl:pdfViewCtrl]];
         
-        [self rnt_sendExportAnnotationCommandWithAction:PTAddAnnotationActionKey annotation:collabAnnot pageNumber:pageNumber annotType:[RNTPTDocumentView stringForAnnotType:[annot GetType]]];
+        [self rnt_sendExportAnnotationCommandWithAction:PTAddAnnotationActionKey annotation:collabAnnot pageNumber:pageNumber annotType:[RNTPTDocumentView stringForAnnotType:annot type:[annot GetType]]];
     }
 }
 
@@ -4202,7 +4202,7 @@ NS_ASSUME_NONNULL_END
     if ([self.delegate respondsToSelector:@selector(annotationChanged:annotation:action:)]) {
         [self.delegate annotationChanged:self annotation:@{
             PTAnnotationIdKey: annotId,
-            PTAnnotationTypeKey: [RNTPTDocumentView stringForAnnotType:[annot GetType]],
+            PTAnnotationTypeKey: [RNTPTDocumentView stringForAnnotType:annot type:[annot GetType]],
             PTAnnotationPageNumberKey: @(pageNumber),
         } action:PTModifyAnnotationActionKey];
     }
@@ -4214,7 +4214,7 @@ NS_ASSUME_NONNULL_END
         [collabAnnot setAnnotationID:annotId];
         [collabAnnot setXfdf:[self generateXfdfCommand:[[PTVectorAnnot alloc] init] modified:annots deleted:[[PTVectorAnnot alloc] init] pdfViewCtrl:pdfViewCtrl]];
         
-        [self rnt_sendExportAnnotationCommandWithAction:PTModifyAnnotationActionKey annotation:collabAnnot pageNumber:pageNumber annotType:[RNTPTDocumentView stringForAnnotType:[annot GetType]]];
+        [self rnt_sendExportAnnotationCommandWithAction:PTModifyAnnotationActionKey annotation:collabAnnot pageNumber:pageNumber annotType:[RNTPTDocumentView stringForAnnotType:annot type:[annot GetType]]];
     }
 }
 
@@ -4247,7 +4247,7 @@ NS_ASSUME_NONNULL_END
         [self.delegate annotationChanged:self annotation:@{
             PTAnnotationIdKey: annotId,
             PTAnnotationPageNumberKey: @(pageNumber),
-            PTAnnotationTypeKey: [RNTPTDocumentView stringForAnnotType:[annot GetType]],
+            PTAnnotationTypeKey: [RNTPTDocumentView stringForAnnotType: annot type:[annot GetType]],
         } action:PTRemoveAnnotationActionKey];
     }
     if (!self.collaborationManager) {
@@ -4258,7 +4258,7 @@ NS_ASSUME_NONNULL_END
         [collabAnnot setAnnotationID:annotId];
         [collabAnnot setXfdf:[self generateXfdfCommand:[[PTVectorAnnot alloc] init] modified:annots deleted:[[PTVectorAnnot alloc] init] pdfViewCtrl:pdfViewCtrl]];
         
-        [self rnt_sendExportAnnotationCommandWithAction:PTDeleteAnnotationActionKey annotation:collabAnnot pageNumber:pageNumber annotType:[RNTPTDocumentView stringForAnnotType:[annot GetType]]];
+        [self rnt_sendExportAnnotationCommandWithAction:PTDeleteAnnotationActionKey annotation:collabAnnot pageNumber:pageNumber annotType:[RNTPTDocumentView stringForAnnotType:annot type:[annot GetType]]];
     }
 }
 
@@ -4290,7 +4290,7 @@ NS_ASSUME_NONNULL_END
         [self.delegate annotationFlattened:self annotation:@{
             PTAnnotationIdKey: [annotId isEqualToString:@""] ? [NSNull null] : annotId,
             PTAnnotationPageNumberKey: @(pageNumber),
-            PTAnnotationTypeKey: [RNTPTDocumentView stringForAnnotType:[annot GetType]],
+            PTAnnotationTypeKey: [RNTPTDocumentView stringForAnnotType:annot type:[annot GetType]],
         }];
     }
 }
@@ -4342,7 +4342,7 @@ NS_ASSUME_NONNULL_END
             [collabAnnot setAnnotationID:annotId];
             [collabAnnot setXfdf:[self generateXfdfCommand:[[PTVectorAnnot alloc] init] modified:annots deleted:[[PTVectorAnnot alloc] init] pdfViewCtrl:pdfViewCtrl]];
             
-            [self rnt_sendExportAnnotationCommandWithAction:PTModifyAnnotationActionKey annotation:collabAnnot pageNumber:pageNumber annotType:[RNTPTDocumentView stringForAnnotType:[annot GetType]]];
+            [self rnt_sendExportAnnotationCommandWithAction:PTModifyAnnotationActionKey annotation:collabAnnot pageNumber:pageNumber annotType:[RNTPTDocumentView stringForAnnotType:annot type:[annot GetType]]];
         }
     }
 }
@@ -5923,7 +5923,7 @@ NS_ASSUME_NONNULL_END
     return Nil;
 }
 
-+ (NSString *)stringForAnnotType:(PTAnnotType)type {
++ (NSString *)stringForAnnotType:(PTAnnot *)annot type:(PTAnnotType)type {
     if (type == e_ptText) {
         return PTAnnotationCreateStickyToolKey;
     } else if (type == e_ptLink) {
@@ -5963,7 +5963,7 @@ NS_ASSUME_NONNULL_END
     } else if (type == e_ptMovie) {
         return @"";
     } else if (type == e_ptWidget) {
-        return PTFormCreateTextFieldToolKey;
+        return [self getWidgetFieldType:annot];
     } else if (type == e_ptScreen) {
         return @"";
     } else if (type == e_ptPrinterMark) {
@@ -5981,6 +5981,32 @@ NS_ASSUME_NONNULL_END
     } else if (type == e_ptRichMedia) {
         return @"";
     } else if (type == e_ptUnknown) {
+        return @"";
+    }
+    
+    return @"";
+}
+
++ (NSString *)getWidgetFieldType:(PTAnnot *)annot
+{
+    @try {
+        PTWidget *widget = [[PTWidget alloc] initWithAnn:annot];
+        PTField *field = [widget GetField];
+        PTFieldType fieldType = [field GetType];
+        
+        if (fieldType == e_pttext) {
+            return PTFormCreateTextFieldToolKey;
+        } else if (fieldType == e_ptcheck) {
+            return PTFormCreateCheckboxFieldToolKey;
+        } else if (fieldType == e_ptradio) {
+            return PTFormCreateRadioFieldToolKey;
+        } else if (fieldType == e_ptchoice) {
+            return PTFormCreateComboBoxFieldToolKey;
+        } else if (fieldType == e_ptsignature) {
+            return PTFormCreateSignatureFieldToolKey;
+        }
+    }
+    @catch (NSException *e) {
         return @"";
     }
     

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -5987,32 +5987,6 @@ NS_ASSUME_NONNULL_END
     return @"";
 }
 
-+ (NSString *)getWidgetFieldType:(PTAnnot *)annot
-{
-    @try {
-        PTWidget *widget = [[PTWidget alloc] initWithAnn:annot];
-        PTField *field = [widget GetField];
-        PTFieldType fieldType = [field GetType];
-        
-        if (fieldType == e_pttext) {
-            return PTFormCreateTextFieldToolKey;
-        } else if (fieldType == e_ptcheck) {
-            return PTFormCreateCheckboxFieldToolKey;
-        } else if (fieldType == e_ptradio) {
-            return PTFormCreateRadioFieldToolKey;
-        } else if (fieldType == e_ptchoice) {
-            return PTFormCreateComboBoxFieldToolKey;
-        } else if (fieldType == e_ptsignature) {
-            return PTFormCreateSignatureFieldToolKey;
-        }
-    }
-    @catch (NSException *e) {
-        return @"";
-    }
-    
-    return @"";
-}
-
 + (PTAnnotType)annotTypeForString:(NSString *)string {
     if ([string isEqualToString:PTAnnotationCreateStickyToolKey]) {
         return e_ptText;
@@ -6104,6 +6078,32 @@ NS_ASSUME_NONNULL_END
         }
     }
     return nil;
+}
+
++ (NSString *)getWidgetFieldType:(PTAnnot *)annot
+{
+    @try {
+        PTWidget *widget = [[PTWidget alloc] initWithAnn:annot];
+        PTField *field = [widget GetField];
+        PTFieldType fieldType = [field GetType];
+        
+        if (fieldType == e_pttext) {
+            return PTFormCreateTextFieldToolKey;
+        } else if (fieldType == e_ptcheck) {
+            return PTFormCreateCheckboxFieldToolKey;
+        } else if (fieldType == e_ptradio) {
+            return PTFormCreateRadioFieldToolKey;
+        } else if (fieldType == e_ptchoice) {
+            return PTFormCreateComboBoxFieldToolKey;
+        } else if (fieldType == e_ptsignature) {
+            return PTFormCreateSignatureFieldToolKey;
+        }
+    }
+    @catch (NSException *e) {
+        return @"";
+    }
+    
+    return @"";
 }
 
 #pragma mark - Display Responsiveness

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "3.0.3-18",
+  "version": "3.0.3-19",
   "description": "React Native Pdftron",
   "main": "./lib/index.js",
   "typings": "index.ts",


### PR DESCRIPTION
Different annotation form field types should now should their respective form field annotations

![image](https://user-images.githubusercontent.com/15988850/232888790-4c7b259d-ecf3-4013-ba01-721ca2007721.png)

tested with this app.js:
```
/**
 * Sample React Native App
 * https://github.com/facebook/react-native
 *
 * @format
 * @flow strict-local
 */

 import React, {useRef} from 'react';
 import {Alert, BackHandler, PermissionsAndroid, Platform} from 'react-native';
 
 import {DocumentView, RNPdftron} from 'react-native-pdftron';
 
 const App = () => {
   const viewer = useRef(null);
 
   React.useEffect(() => {
     RNPdftron.initialize('');
     RNPdftron.enableJavaScript(true);
   }, []);
 
   React.useEffect(() => {
     if (Platform.OS === 'android') {
       requestStoragePermission();
     }
   }, []);
 
   const requestStoragePermission = async () => {
     try {
       const granted = await PermissionsAndroid.request(
         PermissionsAndroid.PERMISSIONS.WRITE_EXTERNAL_STORAGE,
       );
       if (granted === PermissionsAndroid.RESULTS.GRANTED) {
         // this.setState({
         //   permissionGranted: true,
         // });
         console.log('Storage permission granted');
       } else {
         // this.setState({
         //   permissionGranted: false,
         // });
         console.log('Storage permission denied');
       }
     } catch (err) {
       console.warn(err);
     }
   };
 
   const onLeadingNavButtonPressed = () => {
     console.log('leading nav button pressed');
     if (Platform.OS === 'ios') {
       Alert.alert(
         'App',
         'onLeadingNavButtonPressed',
         [{text: 'OK', onPress: () => console.log('OK Pressed')}],
         {cancelable: true},
       );
     } else {
       BackHandler.exitApp();
     }
   };
 
   return (
     <DocumentView
       document={'https://www.africau.edu/images/default/sample.pdf'}
       showLeadingNavButton={true}
       ref={viewer}
       leadingNavButtonIcon={
         Platform.OS === 'ios'
           ? 'ic_close_black_24px.png'
           : 'ic_arrow_back_white_24dp'
       }
       onLeadingNavButtonPressed={onLeadingNavButtonPressed}
       onAnnotationChanged={({action, annotations}) => {
         console.log('---------');
         console.log('--------Annotation edit action is------', action);
         console.log('---------');
         annotations.forEach(annotation => {
           console.log('The id of changed annotation is', annotation.id);
           console.log('It is in page', annotation.pageNumber);
           console.log('Its type is', annotation.type);
         });
       }}
     />
   );
 };
 
 export default App;
```
 