### PR TITLE
topAppBarNavRightBar checks if button exists in other navigation bar/UI bars 

### DIFF
--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -2602,7 +2602,7 @@ NS_ASSUME_NONNULL_END
                                 inViewController:documentController];
                 [self removeRightBarButtonItem:bottomToolbarItem
                                 inViewController:documentController];
-                [self removeRightBarButtonItem:bottomToolbarItem
+                [self removeToolbarButtonItem:bottomToolbarItem
                                 inViewController:documentController];
                 
                 [bottomToolbarItems addObject:bottomToolbarItem];

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -2575,10 +2575,17 @@ NS_ASSUME_NONNULL_END
             UIBarButtonItem *rightBarItem = [self itemForButton:rightBarItemString
                                                inViewController:documentController];
             if (rightBarItem) {
+                [self removeLeftBarButtonItem:rightBarItem
+                                     inViewController:documentController];
+                [self removeToolbarButtonItem:rightBarItem
+                                     inViewController:documentController];
+                
+                
                 [rightBarItems addObject:rightBarItem];
             }
         }
         NSArray * reversedArray = [[rightBarItems reverseObjectEnumerator] allObjects];
+        
         documentController.navigationItem.rightBarButtonItems = reversedArray;
     }
     
@@ -2590,8 +2597,10 @@ NS_ASSUME_NONNULL_END
             UIBarButtonItem *bottomToolbarItem = [self itemForButton:bottomToolbarString
                                                     inViewController:documentController];
             if (bottomToolbarItem) {
-                [self ensureUniqueBottomBarButtonItem:bottomToolbarItem
-                                     inViewController:documentController];
+                [self removeLeftBarButtonItem:bottomToolbarItem
+                                inViewController:documentController];
+                [self removeRightBarButtonItem:bottomToolbarItem
+                                inViewController:documentController];
                 
                 [bottomToolbarItems addObject:bottomToolbarItem];
                 
@@ -5564,7 +5573,104 @@ NS_ASSUME_NONNULL_END
     return nil;
 }
 
-- (void)ensureUniqueBottomBarButtonItem:(UIBarButtonItem *)item
+- (void)removeToolbarButtonItem:(UIBarButtonItem *)item
+                       inViewController:(PTDocumentBaseViewController *)documentViewController
+{
+    if (!item) {
+        return;
+    }
+    
+    if ([documentViewController isKindOfClass:[PTDocumentController class]]) {
+        PTDocumentController * const documentController = (PTDocumentController *)documentViewController;
+
+        NSArray<UIBarButtonItem *> * const compactToolbarItems = [documentController toolbarItemsForSizeClass:UIUserInterfaceSizeClassCompact];
+        if ([compactToolbarItems containsObject:item]) {
+            NSMutableArray<UIBarButtonItem *> * const mutableToolbarItems = [compactToolbarItems mutableCopy];
+            
+            [mutableToolbarItems removeObject:item];
+            
+            [documentController setToolbarItems: [mutableToolbarItems copy]
+                                   forSizeClass:UIUserInterfaceSizeClassCompact
+                                       animated: NO];
+
+            
+        }
+        
+        NSArray<UIBarButtonItem *> * const regularToolbarItems = [documentController toolbarItemsForSizeClass:UIUserInterfaceSizeClassRegular];
+        if ([regularToolbarItems containsObject:item]) {
+            NSMutableArray<UIBarButtonItem *> * const mutableToolbarItems = [regularToolbarItems mutableCopy];
+            
+            [mutableToolbarItems removeObject:item];
+            
+            [documentController setToolbarItems:[mutableToolbarItems copy]
+                                     forSizeClass:UIUserInterfaceSizeClassRegular
+                                         animated:NO];
+        }
+        
+    } else {
+        PTDocumentController * const documentController = (PTDocumentController *)documentViewController;
+        
+        NSArray<UIBarButtonItem *> * const toolbarItems = documentController.toolbarItems;
+        if ([toolbarItems containsObject:item]) {
+            NSMutableArray<UIBarButtonItem *> * const mutableToolbarItems = [toolbarItems mutableCopy];
+            
+            [mutableToolbarItems removeObject:item];
+            
+            [documentController setToolbarItems:[mutableToolbarItems copy]
+                                       animated:NO];
+        }
+    }
+}
+
+- (void)removeRightBarButtonItem:(UIBarButtonItem *)item
+                       inViewController:(PTDocumentBaseViewController *)documentViewController
+{
+    if (!item) {
+        return;
+    }
+    
+    if ([documentViewController isKindOfClass:[PTDocumentController class]]) {
+        PTDocumentController * const documentController = (PTDocumentController *)documentViewController;
+        PTDocumentNavigationItem * const navigationItem = documentController.navigationItem;
+        
+        NSArray<UIBarButtonItem *> * const compactRightBarButtonItems = [navigationItem rightBarButtonItemsForSizeClass:UIUserInterfaceSizeClassCompact];
+        if ([compactRightBarButtonItems containsObject:item]) {
+            NSMutableArray<UIBarButtonItem *> * const mutableRightBarButtonItems = [compactRightBarButtonItems mutableCopy];
+            
+            [mutableRightBarButtonItems removeObject:item];
+            
+            [navigationItem setRightBarButtonItems:[mutableRightBarButtonItems copy]
+                                      forSizeClass:UIUserInterfaceSizeClassCompact
+                                          animated:NO];
+        }
+        
+        NSArray<UIBarButtonItem *> * const regularRightBarButtonItems = [navigationItem rightBarButtonItemsForSizeClass:UIUserInterfaceSizeClassRegular];
+        if ([regularRightBarButtonItems containsObject:item]) {
+            NSMutableArray<UIBarButtonItem *> * const mutableRightBarButtonItems = [regularRightBarButtonItems mutableCopy];
+            
+            [mutableRightBarButtonItems removeObject:item];
+            
+            [navigationItem setRightBarButtonItems:[mutableRightBarButtonItems copy]
+                                      forSizeClass:UIUserInterfaceSizeClassRegular
+                                          animated:NO];
+        }
+
+    } else {
+        UINavigationItem * const navigationItem = documentViewController.navigationItem;
+        
+        NSArray<UIBarButtonItem *> * const rightBarButtonItems = navigationItem.rightBarButtonItems;
+        if ([rightBarButtonItems containsObject:item]) {
+            NSMutableArray<UIBarButtonItem *> * const mutableRightBarButtonItems = [rightBarButtonItems mutableCopy];
+            
+            [mutableRightBarButtonItems removeObject:item];
+            
+            [navigationItem setRightBarButtonItems:[mutableRightBarButtonItems copy]
+                                          animated:NO];
+        }
+    }
+}
+
+- (void)removeLeftBarButtonItem:(UIBarButtonItem *)item
                        inViewController:(PTDocumentBaseViewController *)documentViewController
 {
     if (!item) {
@@ -5597,27 +5703,6 @@ NS_ASSUME_NONNULL_END
                                          animated:NO];
         }
         
-        NSArray<UIBarButtonItem *> * const compactRightBarButtonItems = [navigationItem rightBarButtonItemsForSizeClass:UIUserInterfaceSizeClassCompact];
-        if ([compactRightBarButtonItems containsObject:item]) {
-            NSMutableArray<UIBarButtonItem *> * const mutableRightBarButtonItems = [compactRightBarButtonItems mutableCopy];
-            
-            [mutableRightBarButtonItems removeObject:item];
-            
-            [navigationItem setRightBarButtonItems:[mutableRightBarButtonItems copy]
-                                      forSizeClass:UIUserInterfaceSizeClassCompact
-                                          animated:NO];
-        }
-        
-        NSArray<UIBarButtonItem *> * const regularRightBarButtonItems = [navigationItem rightBarButtonItemsForSizeClass:UIUserInterfaceSizeClassRegular];
-        if ([regularRightBarButtonItems containsObject:item]) {
-            NSMutableArray<UIBarButtonItem *> * const mutableRightBarButtonItems = [regularRightBarButtonItems mutableCopy];
-            
-            [mutableRightBarButtonItems removeObject:item];
-            
-            [navigationItem setRightBarButtonItems:[mutableRightBarButtonItems copy]
-                                      forSizeClass:UIUserInterfaceSizeClassRegular
-                                          animated:NO];
-        }
     } else {
         UINavigationItem * const navigationItem = documentViewController.navigationItem;
         
@@ -5629,16 +5714,6 @@ NS_ASSUME_NONNULL_END
             
             [navigationItem setLeftBarButtonItems:[mutableLeftBarButtonItems copy]
                                          animated:NO];
-        }
-
-        NSArray<UIBarButtonItem *> * const rightBarButtonItems = navigationItem.rightBarButtonItems;
-        if ([rightBarButtonItems containsObject:item]) {
-            NSMutableArray<UIBarButtonItem *> * const mutableRightBarButtonItems = [rightBarButtonItems mutableCopy];
-            
-            [mutableRightBarButtonItems removeObject:item];
-            
-            [navigationItem setRightBarButtonItems:[mutableRightBarButtonItems copy]
-                                          animated:NO];
         }
     }
 }

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -2580,7 +2580,6 @@ NS_ASSUME_NONNULL_END
                 [self removeToolbarButtonItem:rightBarItem
                                      inViewController:documentController];
                 
-                
                 [rightBarItems addObject:rightBarItem];
             }
         }
@@ -5593,9 +5592,7 @@ NS_ASSUME_NONNULL_END
                                    forSizeClass:UIUserInterfaceSizeClassCompact
                                        animated: NO];
 
-            
         }
-        
         NSArray<UIBarButtonItem *> * const regularToolbarItems = [documentController toolbarItemsForSizeClass:UIUserInterfaceSizeClassRegular];
         if ([regularToolbarItems containsObject:item]) {
             NSMutableArray<UIBarButtonItem *> * const mutableToolbarItems = [regularToolbarItems mutableCopy];
@@ -5606,7 +5603,6 @@ NS_ASSUME_NONNULL_END
                                      forSizeClass:UIUserInterfaceSizeClassRegular
                                          animated:NO];
         }
-        
     } else {
         PTDocumentController * const documentController = (PTDocumentController *)documentViewController;
         
@@ -5628,7 +5624,7 @@ NS_ASSUME_NONNULL_END
     if (!item) {
         return;
     }
-    
+
     if ([documentViewController isKindOfClass:[PTDocumentController class]]) {
         PTDocumentController * const documentController = (PTDocumentController *)documentViewController;
         PTDocumentNavigationItem * const navigationItem = documentController.navigationItem;
@@ -5643,7 +5639,6 @@ NS_ASSUME_NONNULL_END
                                       forSizeClass:UIUserInterfaceSizeClassCompact
                                           animated:NO];
         }
-        
         NSArray<UIBarButtonItem *> * const regularRightBarButtonItems = [navigationItem rightBarButtonItemsForSizeClass:UIUserInterfaceSizeClassRegular];
         if ([regularRightBarButtonItems containsObject:item]) {
             NSMutableArray<UIBarButtonItem *> * const mutableRightBarButtonItems = [regularRightBarButtonItems mutableCopy];
@@ -5654,7 +5649,6 @@ NS_ASSUME_NONNULL_END
                                       forSizeClass:UIUserInterfaceSizeClassRegular
                                           animated:NO];
         }
-
     } else {
         UINavigationItem * const navigationItem = documentViewController.navigationItem;
         
@@ -5691,7 +5685,6 @@ NS_ASSUME_NONNULL_END
                                      forSizeClass:UIUserInterfaceSizeClassCompact
                                          animated:NO];
         }
-        
         NSArray<UIBarButtonItem *> * const regularLeftBarButtonItems = [navigationItem leftBarButtonItemsForSizeClass:UIUserInterfaceSizeClassRegular];
         if ([regularLeftBarButtonItems containsObject:item]) {
             NSMutableArray<UIBarButtonItem *> * const mutableLeftBarButtonItems = [regularLeftBarButtonItems mutableCopy];
@@ -5702,7 +5695,6 @@ NS_ASSUME_NONNULL_END
                                      forSizeClass:UIUserInterfaceSizeClassRegular
                                          animated:NO];
         }
-        
     } else {
         UINavigationItem * const navigationItem = documentViewController.navigationItem;
         

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -2576,11 +2576,11 @@ NS_ASSUME_NONNULL_END
                                                inViewController:documentController];
             if (rightBarItem) {
                 [self removeLeftBarButtonItem:rightBarItem
-                                     inViewController:documentController];
+                                inViewController:documentController];
                 [self removeToolbarButtonItem:rightBarItem
-                                     inViewController:documentController];
+                                inViewController:documentController];
                 [self removeRightBarButtonItem:rightBarItem
-                                     inViewController:documentController];
+                                inViewController:documentController];
                 
                 [rightBarItems addObject:rightBarItem];
             }
@@ -2603,7 +2603,7 @@ NS_ASSUME_NONNULL_END
                 [self removeRightBarButtonItem:bottomToolbarItem
                                 inViewController:documentController];
                 [self removeRightBarButtonItem:bottomToolbarItem
-                                     inViewController:documentController];
+                                inViewController:documentController];
                 
                 [bottomToolbarItems addObject:bottomToolbarItem];
                 

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -2579,6 +2579,8 @@ NS_ASSUME_NONNULL_END
                                      inViewController:documentController];
                 [self removeToolbarButtonItem:rightBarItem
                                      inViewController:documentController];
+                [self removeRightBarButtonItem:rightBarItem
+                                     inViewController:documentController];
                 
                 [rightBarItems addObject:rightBarItem];
             }
@@ -2600,6 +2602,8 @@ NS_ASSUME_NONNULL_END
                                 inViewController:documentController];
                 [self removeRightBarButtonItem:bottomToolbarItem
                                 inViewController:documentController];
+                [self removeRightBarButtonItem:bottomToolbarItem
+                                     inViewController:documentController];
                 
                 [bottomToolbarItems addObject:bottomToolbarItem];
                 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "3.0.3-19",
+  "version": "3.0.3-20",
   "description": "React Native Pdftron",
   "main": "./lib/index.js",
   "typings": "index.ts",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "3.0.3-20",
+  "version": "3.0.3-21",
   "description": "React Native Pdftron",
   "main": "./lib/index.js",
   "typings": "index.ts",


### PR DESCRIPTION
fixed issue to force button to top app nav bar right bar if toolbar button is found in other app bar when using prop in app.js config
```
        topAppNavBarRightBar={[
          Config.Buttons.searchButton,
          Config.Buttons.thumbnailsButton,
          Config.Buttons.viewControlsButton,
        ]}
```
also refactored ensureUniqueBottomBarButtonItem to use 3 functions instead of the 1 for specificity:
- removeToolbarButtonItem
- removeLeftBarButtonItem
- removeRightBarButtonItem

on iOS16.2 iPad (Simulator):
(before)
![image](https://user-images.githubusercontent.com/15988850/236303990-d3a70ee0-fecb-417b-b859-d2cb417a95bd.png)

(after)
![image](https://user-images.githubusercontent.com/15988850/236303813-75e6b686-ee7d-4a67-9f8c-17692aa082d7.png)

