### PR TITLE
Fix package version update script again

### DIFF
--- a/.github/workflows/jsBuilder.yml
+++ b/.github/workflows/jsBuilder.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Get Latest package.json
         run: |
           git pull origin ${{ github.head_ref }}
-          git merge origin/master
+          git checkout origin/master package.json
 
       - name: Update package.json
         run: node scripts/update_version.js

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "3.0.3-31",
+  "version": "3.0.3-32",
   "description": "React Native Pdftron",
   "main": "./lib/index.js",
   "typings": "index.ts",


### PR DESCRIPTION
- Revert merge master, instead just checkout
- Upon further investigation, it seems that the `-m` tag did nothing, so we can just take it out.