### PR TITLE
Remove Android-Kotlin-Extensions library

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,6 +1,6 @@
 
 buildscript {
-    def kotlinVersion = rootProject.ext.has('kotlinVersion') ? rootProject.ext.get('kotlinVersion') : "1.6.20"
+    def kotlinVersion = rootProject.ext.has('kotlinVersion') ? rootProject.ext.get('kotlinVersion') : "1.8.22"
     repositories {
         google()
         mavenCentral()

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -24,7 +24,6 @@ rootProject.allprojects {
 
 apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 
 android {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "3.0.3-32",
+  "version": "3.0.3-33",
   "description": "React Native Pdftron",
   "main": "./lib/index.js",
   "typings": "index.ts",


### PR DESCRIPTION
Any mention of android-kotlin-extensions library is removed
was deprecated as of this error:

> The Android extensions ('kotlin-android-extensions') compiler plugin is no longer supported. Please use kotlin parcelize and view binding. More information: https://goo.gle/kotlin-android-extensions-deprecation