### PR TITLE
Add rect area measurement as android only tool

### DIFF
--- a/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
+++ b/android/src/main/java/com/pdftron/reactnative/views/DocumentView.java
@@ -1276,6 +1276,8 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
             annotType = AnnotStyle.CUSTOM_ANNOT_TYPE_PERIMETER_MEASURE;
         } else if (TOOL_ANNOTATION_CREATE_AREA_MEASUREMENT.equals(item)) {
             annotType = AnnotStyle.CUSTOM_ANNOT_TYPE_AREA_MEASURE;
+        } else if (TOOL_ANNOTATION_CREATE_RECT_AREA_MEASUREMENT.equals(item)) {
+            annotType = AnnotStyle.CUSTOM_ANNOT_TYPE_RECT_AREA_MEASURE;
         } else if (TOOL_ANNOTATION_CREATE_FILE_ATTACHMENT.equals(item)) {
             annotType = Annot.e_FileAttachment;
         } else if (TOOL_ANNOTATION_CREATE_SOUND.equals(item)) {
@@ -1490,6 +1492,8 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
             mode = ToolManager.ToolMode.PERIMETER_MEASURE_CREATE;
         } else if (TOOL_ANNOTATION_CREATE_AREA_MEASUREMENT.equals(item)) {
             mode = ToolManager.ToolMode.AREA_MEASURE_CREATE;
+        } else if (TOOL_ANNOTATION_CREATE_RECT_AREA_MEASUREMENT.equals(item)) {
+            mode = ToolManager.ToolMode.RECT_AREA_MEASURE_CREATE;
         } else if (TOOL_ANNOTATION_CREATE_FILE_ATTACHMENT.equals(item)) {
             mode = ToolManager.ToolMode.FILE_ATTACHMENT_CREATE;
         } else if (TOOL_ANNOTATION_CREATE_SOUND.equals(item)) {
@@ -1730,6 +1734,8 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
             buttonId = DefaultToolbars.ButtonId.PERIMETER.value();
         } else if (TOOL_ANNOTATION_CREATE_AREA_MEASUREMENT.equals(item)) {
             buttonId = DefaultToolbars.ButtonId.AREA.value();
+        } else if (TOOL_ANNOTATION_CREATE_RECT_AREA_MEASUREMENT.equals(item)) {
+            buttonId = DefaultToolbars.ButtonId.RECT_AREA.value();
         } else if (TOOL_ANNOTATION_CREATE_FILE_ATTACHMENT.equals(item)) {
             buttonId = DefaultToolbars.ButtonId.ATTACHMENT.value();
         } else if (TOOL_ANNOTATION_CREATE_SOUND.equals(item)) {
@@ -1897,6 +1903,8 @@ public class DocumentView extends com.pdftron.pdf.controls.DocumentView2 {
             buttonType = ToolbarButtonType.PERIMETER;
         } else if (TOOL_ANNOTATION_CREATE_AREA_MEASUREMENT.equals(item)) {
             buttonType = ToolbarButtonType.AREA;
+        } else if (TOOL_ANNOTATION_CREATE_RECT_AREA_MEASUREMENT.equals(item)) {
+            buttonType = ToolbarButtonType.RECT_AREA;
         } else if (TOOL_ANNOTATION_CREATE_FILE_ATTACHMENT.equals(item)) {
             buttonType = ToolbarButtonType.ATTACHMENT;
         } else if (TOOL_ANNOTATION_CREATE_SOUND.equals(item)) {

--- a/lib/src/Config/Config.js
+++ b/lib/src/Config/Config.js
@@ -89,7 +89,6 @@ export const Config = {
         annotationCreateDistanceMeasurement: 'AnnotationCreateDistanceMeasurement',
         annotationCreatePerimeterMeasurement: 'AnnotationCreatePerimeterMeasurement',
         annotationCreateAreaMeasurement: 'AnnotationCreateAreaMeasurement',
-        annotationCreateRectAreaMeasurement: 'AnnotationCreateRectAreaMeasurement',
         annotationCreateFileAttachment: 'AnnotationCreateFileAttachment',
         annotationCreateSound: 'AnnotationCreateSound',
         annotationCreateRedaction: 'AnnotationCreateRedaction',
@@ -113,6 +112,7 @@ export const Config = {
         pencilKitDrawing: 'PencilKitDrawing',
         // Android only.
         annotationCreateLinkText: 'AnnotationCreateLinkText',
+        annotationCreateRectAreaMeasurement: 'AnnotationCreateRectAreaMeasurement',
     },
     // FitMode define how a page should fit relative to the viewer, alternatively, the default zoom level
     FitMode: {

--- a/lib/src/Config/Config.js
+++ b/lib/src/Config/Config.js
@@ -89,6 +89,7 @@ export const Config = {
         annotationCreateDistanceMeasurement: 'AnnotationCreateDistanceMeasurement',
         annotationCreatePerimeterMeasurement: 'AnnotationCreatePerimeterMeasurement',
         annotationCreateAreaMeasurement: 'AnnotationCreateAreaMeasurement',
+        annotationCreateRectAreaMeasurement: 'AnnotationCreateRectAreaMeasurement',
         annotationCreateFileAttachment: 'AnnotationCreateFileAttachment',
         annotationCreateSound: 'AnnotationCreateSound',
         annotationCreateRedaction: 'AnnotationCreateRedaction',
@@ -112,7 +113,6 @@ export const Config = {
         pencilKitDrawing: 'PencilKitDrawing',
         // Android only.
         annotationCreateLinkText: 'AnnotationCreateLinkText',
-        annotationCreateRectAreaMeasurement: 'AnnotationCreateRectAreaMeasurement'
     },
     // FitMode define how a page should fit relative to the viewer, alternatively, the default zoom level
     FitMode: {

--- a/lib/src/Config/Config.js
+++ b/lib/src/Config/Config.js
@@ -112,6 +112,7 @@ export const Config = {
         pencilKitDrawing: 'PencilKitDrawing',
         // Android only.
         annotationCreateLinkText: 'AnnotationCreateLinkText',
+        annotationCreateRectAreaMeasurement: 'AnnotationCreateRectAreaMeasurement'
     },
     // FitMode define how a page should fit relative to the viewer, alternatively, the default zoom level
     FitMode: {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "3.0.3-33",
+  "version": "3.0.3-34",
   "description": "React Native Pdftron",
   "main": "./lib/index.js",
   "typings": "index.ts",

--- a/src/Config/Config.ts
+++ b/src/Config/Config.ts
@@ -92,6 +92,7 @@ export const Config = {
     annotationCreateDistanceMeasurement: 'AnnotationCreateDistanceMeasurement',
     annotationCreatePerimeterMeasurement: 'AnnotationCreatePerimeterMeasurement',
     annotationCreateAreaMeasurement: 'AnnotationCreateAreaMeasurement',
+    annotationCreateRectAreaMeasurement: 'AnnotationCreateRectAreaMeasurement',
     annotationCreateFileAttachment: 'AnnotationCreateFileAttachment',
     annotationCreateSound: 'AnnotationCreateSound',
     annotationCreateRedaction: 'AnnotationCreateRedaction',

--- a/src/Config/Config.ts
+++ b/src/Config/Config.ts
@@ -92,7 +92,6 @@ export const Config = {
     annotationCreateDistanceMeasurement: 'AnnotationCreateDistanceMeasurement',
     annotationCreatePerimeterMeasurement: 'AnnotationCreatePerimeterMeasurement',
     annotationCreateAreaMeasurement: 'AnnotationCreateAreaMeasurement',
-    annotationCreateRectAreaMeasurement: 'AnnotationCreateRectAreaMeasurement',
     annotationCreateFileAttachment: 'AnnotationCreateFileAttachment',
     annotationCreateSound: 'AnnotationCreateSound',
     annotationCreateRedaction: 'AnnotationCreateRedaction',
@@ -118,6 +117,7 @@ export const Config = {
 
     // Android only.
     annotationCreateLinkText: 'AnnotationCreateLinkText',
+    annotationCreateRectAreaMeasurement: 'AnnotationCreateRectAreaMeasurement',
   },
 
   // FitMode define how a page should fit relative to the viewer, alternatively, the default zoom level


### PR DESCRIPTION
android only implementation

test by adding `Config.Tools.annotationCreateRectAreaMeasurement` to any of the document view props like disabledTools, etc.