### PR TITLE
Update RNTPTDocumentView.m

### DIFF
--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -5885,9 +5885,6 @@ NS_ASSUME_NONNULL_END
     else if ( [key isEqualToString:PTAnnotationCreateDotStampKey] ) {
         return [PTDotStampCreate class];
     }
-    else if (toolClass == [RNTPTDigitalSignatureTool class]) {
-        return PTAnnotationCreateSignatureToolKey;
-    }
     
     if (@available(iOS 13.1, *)) {
         if ([key isEqualToString:PTPencilKitDrawingToolKey]) {
@@ -6028,6 +6025,9 @@ NS_ASSUME_NONNULL_END
     }
     else if (toolClass == [PTDotStampCreate class]) {
         return PTAnnotationCreateDotStampKey;
+    }
+    else if (toolClass == [RNTPTDigitalSignatureTool class]) {
+        return PTAnnotationCreateSignatureToolKey;
     }
     
     if (@available(iOS 13.1, *)) {

--- a/ios/RNTPTDocumentView.m
+++ b/ios/RNTPTDocumentView.m
@@ -4404,6 +4404,12 @@ NS_ASSUME_NONNULL_END
     }
 
     PTTool *tool = self.currentDocumentViewController.toolManager.tool;
+
+    if([tool isKindOfClass:[PTDigitalSignatureTool class]]){
+        [(PTDigitalSignatureTool *)tool showSignatureList];
+        return;
+    }
+
     if ([tool isKindOfClass:[PTCreateToolBase class]]) {
         PTCreateToolBase *createTool = (PTCreateToolBase *)tool;
         if ([createTool isUndoManagerEnabled]) {
@@ -5878,6 +5884,9 @@ NS_ASSUME_NONNULL_END
     }
     else if ( [key isEqualToString:PTAnnotationCreateDotStampKey] ) {
         return [PTDotStampCreate class];
+    }
+    else if (toolClass == [RNTPTDigitalSignatureTool class]) {
+        return PTAnnotationCreateSignatureToolKey;
     }
     
     if (@available(iOS 13.1, *)) {


### PR DESCRIPTION
Signature Creation Tool on iOS can now open the signatures list even after creating a signature.