### PR TITLE
[Android] Potential fix for lifecycle issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "3.0.3-35",
+  "version": "3.0.3-36",
   "description": "React Native Pdftron",
   "main": "./lib/index.js",
   "typings": "index.ts",


### PR DESCRIPTION
- Fragment transaction only when activity is started
- Component valid check for PDFViewCtrl and ToolManager on document loaded


Diff with base:
![Screen Shot 2024-02-15 at 9 08 47 AM](https://github.com/PDFTron/pdftron-react-native/assets/20527369/345e7a5e-2e5c-40a5-b1ee-7caa8f0760d9)
