### PR TITLE
[iOS] Match Android implementation of `importAnnotations`

### DIFF
--- a/API.md
+++ b/API.md
@@ -2580,7 +2580,7 @@ Parameters:
 Name | Type | Description
 --- | --- | ---
 xfdf | string | annotation string in XFDF format for import
-replace | boolean | whether to replace existing form and annotation data with those imported from the XFDF string (Android only) 
+replace | boolean | whether to replace existing form and annotation data with those imported from the XFDF string
 
 Returns a Promise.
 Promise Parameters:

--- a/ios/RNTPTDocumentView.h
+++ b/ios/RNTPTDocumentView.h
@@ -572,7 +572,7 @@ static NSString * const PTSignaturesManager_signatureDirectory = @"PTSignaturesM
 
 - (nullable NSString *)exportAnnotationsWithOptions:(NSDictionary *)options;
 
-- (nullable NSArray<NSDictionary *> *)importAnnotations:(NSString *)xfdfString;
+- (nullable NSArray<NSDictionary *> *)importAnnotations:(NSString *)xfdfString replace:(BOOL)replace;
 
 - (void)flattenAnnotations:(BOOL)formsOnly;
 

--- a/ios/RNTPTDocumentViewManager.m
+++ b/ios/RNTPTDocumentViewManager.m
@@ -1130,7 +1130,7 @@ RCT_CUSTOM_VIEW_PROPERTY(signatureColors, NSArray, RNTPTDocumentView)
 {
     RNTPTDocumentView *documentView = self.documentViews[tag];
     if (documentView) {
-        return [documentView importAnnotations:xfdfString];
+        return [documentView importAnnotations:xfdfString replace:replace];
     } else {
         @throw [NSException exceptionWithName:NSInvalidArgumentException reason:@"Unable to find DocumentView for tag" userInfo:nil];
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "3.0.3-36",
+  "version": "3.0.3-37",
   "description": "React Native Pdftron",
   "main": "./lib/index.js",
   "typings": "index.ts",


### PR DESCRIPTION
- Add `replace` parameter for iOS implementation of `importAnnotations`
- No longer uses the `PTAnnotationManager` to import the XFDF string

closes REASDK-61