### PR TITLE
[GitHub Actions] Fix TypeScript transpile

### DIFF
--- a/.github/workflows/jsBuilder.yml
+++ b/.github/workflows/jsBuilder.yml
@@ -24,6 +24,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          npm install
           npm i react-native@latest
 
       - name: Build JavaScript files

--- a/.github/workflows/jsBuilder.yml
+++ b/.github/workflows/jsBuilder.yml
@@ -23,9 +23,7 @@ jobs:
           # cache: 'npm'
 
       - name: Install dependencies
-        run: |
-          npm install
-          npm i react-native@latest
+        run: npm install
 
       - name: Build JavaScript files
         run: | # Change line to your build script command.

--- a/.github/workflows/jsBuilder.yml
+++ b/.github/workflows/jsBuilder.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Node setup
         uses: actions/setup-node@v2
         with:
-          node-version: '16'
+          node-version: '22'
           # cache: 'npm'
 
       - name: Install dependencies
@@ -61,7 +61,7 @@ jobs:
       - name: Node setup
         uses: actions/setup-node@v2
         with:
-          node-version: 16
+          node-version: '22'
           registry-url: https://registry.npmjs.org/
 
       - name: Get Latest package.json

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+min-release-age=7

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-pdftron",
   "title": "React Native Pdftron",
-  "version": "3.0.4-30",
+  "version": "3.0.4-31",
   "description": "React Native Pdftron",
   "main": "./lib/index.js",
   "typings": "index.ts",
@@ -29,7 +29,7 @@
   ],
   "readmeFilename": "README.md",
   "dependencies": {
-    "deprecated-react-native-prop-types": "^5.0.0"
+    "deprecated-react-native-prop-types": "*"
   },
   "peerDependencies": {
     "react": "*",
@@ -37,11 +37,10 @@
     "prop-types": "*"
   },
   "devDependencies": {
-    "react": "^18.0.0",
-    "react-native": "^0.73.0",
-    "@types/react": "^18.0.0",
-    "@types/react-native": "^0.73.0",
-    "@types/prop-types": "^15.0.0",
-    "typescript": "^5.2.0"
+    "react": "*",
+    "@types/react": "*",
+    "@types/react-native": "*",
+    "@types/prop-types": "*",
+    "typescript": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   ],
   "readmeFilename": "README.md",
   "dependencies": {
-    "deprecated-react-native-prop-types": "*"
+    "deprecated-react-native-prop-types": "^5.0.0"
   },
   "peerDependencies": {
     "react": "*",
@@ -37,7 +37,7 @@
     "prop-types": "*"
   },
   "devDependencies": {
-    "react": "*",
+    "react": "^18.0.0",
     "react-native": "^0.73.0",
     "@types/react": "^18.0.0",
     "@types/react-native": "^0.73.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "devDependencies": {
     "react": "*",
+    "react-native": "^0.73.0",
     "@types/react": "^18.0.0",
     "@types/react-native": "^0.73.0",
     "@types/prop-types": "^15.0.0",

--- a/package.json
+++ b/package.json
@@ -38,9 +38,9 @@
   },
   "devDependencies": {
     "react": "*",
-    "@types/react": "*",
-    "@types/react-native": "*",
-    "@types/prop-types": "*",
-    "typescript": "*"
+    "@types/react": "^18.0.0",
+    "@types/react-native": "^0.73.0",
+    "@types/prop-types": "^15.0.0",
+    "typescript": "^5.2.0"
   }
 }


### PR DESCRIPTION
The project's dev-dependencies are currently unpinned, so the GitHub Actions will pull in whatever is the latest version without checking for compatibility.

The `min-release-age` config setting for `npm` is also added for a 7-day air gap for package updates.